### PR TITLE
Basic implementation for `basicUnsafeMove`

### DIFF
--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Compat.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Compat.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE CPP        #-}
-{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- |
 module Vecvec.LAPACK.Internal.Compat
   ( getPtr
@@ -40,9 +40,5 @@ unsafeWithForeignPtr = withForeignPtr
 -- | Distance in elements between two pointers. Supplement for `advancePtr`.
 --
 distancePtr :: forall a . Storable a => Ptr a -> Ptr a -> Int
--- distancePtr ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` (sizeOf (undefined :: a))
-distancePtr = distancePtr' undefined -- TODO WTF?? why ambigous??
- where
-    distancePtr' :: Storable a => a -> Ptr a -> Ptr a -> Int
-    distancePtr' x ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` sizeOf x
+distancePtr ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` sizeOf (undefined :: a)
 

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Compat.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Compat.hs
@@ -1,14 +1,17 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE ExplicitForAll #-}
 -- |
 module Vecvec.LAPACK.Internal.Compat
   ( getPtr
   , updPtr
   , unsafeWithForeignPtr
+  , distancePtr
   ) where
 
 import Data.Primitive.Ptr    (Ptr(..))
 import Foreign.ForeignPtr
 import Foreign.Ptr
+import Foreign.Storable
 import GHC.ForeignPtr        (ForeignPtr(..))
 #if MIN_VERSION_base(4,15,0)
 import GHC.ForeignPtr        (unsafeWithForeignPtr)
@@ -33,3 +36,13 @@ updPtr f (ForeignPtr p c) = case f (Ptr p) of { Ptr q -> ForeignPtr q c }
 unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
 unsafeWithForeignPtr = withForeignPtr
 #endif
+
+-- | Distance in elements between two pointers. Supplement for `advancePtr`.
+--
+distancePtr :: forall a . Storable a => Ptr a -> Ptr a -> Int
+-- distancePtr ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` (sizeOf (undefined :: a))
+distancePtr = distancePtr' undefined -- TODO WTF?? why ambigous??
+ where
+    distancePtr' :: Storable a => a -> Ptr a -> Ptr a -> Int
+    distancePtr' x ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` sizeOf x
+

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Vector/Mutable.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Vector/Mutable.hs
@@ -215,6 +215,7 @@ instance VS.Storable a => MVG.MVector MVec a where
   basicUnsafeMove (MVec (VecRepr len 1 fpA)) (MVec (VecRepr _ 1 fpB))
     = MVG.basicUnsafeMove (MVS.MVector len fpA) (MVS.MVector len fpB)
   -- FIXME: We don't handle possible overlap
+  {- for test, which failed
   basicUnsafeMove (MVec (VecRepr len incA fpA)) (MVec (VecRepr _ incB fpB))
     = unsafePrimToPrim
     $ unsafeWithForeignPtr fpA $ \pA ->
@@ -223,6 +224,29 @@ instance VS.Storable a => MVG.MVector MVec a where
                  | otherwise = do pokeElemOff pA (i * incA) =<< peekElemOff pB (i * incB)
                                   loop (i + 1)
       in loop 0
+      -}
+  basicUnsafeMove (MVec (VecRepr _   incA fpA)) (MVec (VecRepr _ incB fpB)) | incA == incB && fpA == fpB = pure ()
+  basicUnsafeMove (MVec (VecRepr len _    _))   (MVec (VecRepr{}))          | len == 0                   = pure ()
+  basicUnsafeMove (MVec (VecRepr len incA fpA)) (MVec (VecRepr _ incB fpB))
+    -- TODO 1: use memmove/memcopy for incA, incB = 1
+    -- TODO 2: what to do if **same** start, but different incA/incB?
+    -- TODO 3: overlapping when different fpA,fpB; incA,incB -- but elements still overlapping sometimes.
+    --
+    -- simple solution for overlapping: just check pointer positions.
+    -- this is not effective, but just to check conception
+    = unsafePrimToPrim
+    $ unsafeWithForeignPtr fpA $ \pA ->
+      unsafeWithForeignPtr fpB $ \pB ->
+      if pA < pB then
+          let loop i | i >= len  = pure ()
+                     | otherwise = do pokeElemOff pA (i * incA) =<< peekElemOff pB (i * incB)
+                                      loop (i + 1)
+          in loop 0
+      else
+          let loop i | i <= 0  = pure ()
+                     | otherwise = do pokeElemOff pA (i * incA) =<< peekElemOff pB (i * incB)
+                                      loop (i - 1)
+          in loop len
 
 
 ----------------------------------------------------------------

--- a/vecvec-lapack/tests/TST/Memory.hs
+++ b/vecvec-lapack/tests/TST/Memory.hs
@@ -3,10 +3,14 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE RecordWildCards    #-}
 -- |
 module TST.Memory (tests) where
 
+import Control.Monad
 import Data.Typeable
+import Data.Foldable
+import Data.Traversable
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import           Test.Tasty
@@ -18,19 +22,37 @@ import Data.Vector.Unboxed   qualified as VU
 import Data.Vector.Storable  qualified as VS
 import Data.Vector.Primitive qualified as VP
 import Data.Vector.Generic.Mutable  qualified as MVG
+import Vecvec.LAPACK.Internal.Vector.Mutable qualified as MVGX
 import Data.Vector.Generic  qualified as VG
 
 import Vecvec.Classes.Slice
 import Vecvec.LAPACK         qualified as VV
 import Vecvec.LAPACK.Internal.Vector.Mutable (Strided(..))
-
+import Foreign.Ptr
+-- import Vecvec.LAPACK.Internal.Compat
+import GHC.ForeignPtr        (ForeignPtr(..))
+import Data.Primitive.Ptr    (Ptr(..))
+import Foreign.Storable
 import Control.Monad.ST
+
+
+getPtr :: ForeignPtr a -> Ptr a
+{-# INLINE getPtr #-}
+getPtr (ForeignPtr addr _) = Ptr addr
+
+
+distancePtr :: forall a . Storable a => Ptr a -> Ptr a -> Int
+-- distancePtr ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` (sizeOf (undefined :: a))
+distancePtr = distancePtr' undefined -- TODO WTF?? why ambigous??
+ where
+    distancePtr' :: Storable a => a -> Ptr a -> Ptr a -> Int
+    distancePtr' x ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` sizeOf x
 
 assertArrays :: (VS.Storable a, Eq a, Show a) => VV.Vec a -> [a] -> VV.Vec a -> [a] -> VV.Vec a -> [a] -> IO ()
 assertArrays givenV1 expectedV1 givenV2 expectedV2 givenV3 expectedV3 = do
-  assertEqual "V1" givenV1 (VG.fromList expectedV1)
-  assertEqual "V2" givenV2 (VG.fromList expectedV2)
-  assertEqual "V3" givenV3 (VG.fromList expectedV3)
+  assertEqual "V1" (VG.fromList expectedV1) givenV1
+  assertEqual "V2" (VG.fromList expectedV2) givenV2
+  assertEqual "V3" (VG.fromList expectedV3) givenV3
 
 
 tests :: TestTree
@@ -63,22 +85,90 @@ tests = testGroup "memory"
                      vecSlice1  [10,11,12,13,14,10,11,12,13,14]
                      vecSlice2  [10,11,12,13,14,15,16,17,18,19]
   , testCase "intersected with stride" $ do
-        let (vecCarrier :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int)  = runST $ do
+        let (vecCarrier :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int, d, d2)  = runST $ do
                     vec <- MVG.generateM 10 (pure . (+10)) -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
                     let vec1 = slice (Strided (0, End) 2) vec
                     let vec2 = slice (2, Length 5) vec
+                    let MVGX.MVec vec1repr = vec1
+                        MVGX.MVec vec2repr = vec2
+                        vb1 = MVGX.vecBuffer vec1repr
+                        vb2 = MVGX.vecBuffer vec2repr
+                        diff = minusPtr (getPtr vb2) (getPtr vb1)
+                        diff2 = distancePtr (getPtr vb1) (getPtr vb2)
                     MVG.basicUnsafeMove vec2 {-target-} vec1 {-source-}
-                    (,,) <$> VG.freeze vec <*> VG.freeze vec1 <*> VG.freeze vec2
+                    (,,,,) <$> VG.freeze vec <*> VG.freeze vec1 <*> VG.freeze vec2 <*> pure diff <*> pure diff2
 
         --print vecCarrier
         --print vecSlice1
         --print vecSlice2
 
+        --putStrLn "***********"
+        --print d
+        --print d2
+        --putStrLn "^^^^^^^^^^^"
         --                      [10,11,12,13,14,15,16,17,18,19
         assertArrays vecCarrier [10,11,10,12,14,16,18,17,18,19]
-                                    -- ^^^^^^^^^^^^^^ reinserted part
+                                    -- ^^^^^----^^^^^ reinserted part
                      vecSlice1  [10,   10,   14,   18,   18]
                      vecSlice2        [10,12,14,16,18]
+  , testCase "options" $ do
+        let carrierLength = 200
+            -- length = 10
+        let targetOffset = 10
+            mvecToList vec = MVG.foldr' (:) [] vec
+        for_ [1..10] $ \length ->
+            for_ [-5,-4..5] $ \sourceTargetOffset ->
+                for_ [1..10] $ \sourceStride ->
+                    for_ [1..10] $ \targetStride -> do
+                        let (vecOriginal' :: [Int], vecSourceLst :: [Int], vecCarrier :: VV.Vec Int, vecSource :: VV.Vec Int, vecTarget :: VV.Vec Int) = runST $ do
+                                let sourceOffset = targetOffset + sourceTargetOffset
+                                let originalVector = [10 .. (10 + carrierLength - 1)]
+                                -- vecOriginal <- MVG.generateM carrierLength (pure . (+10))
+                                vecOriginal <- MVG.generateM carrierLength (\i -> pure $ originalVector !! i)
+                                -- let vecOriginal = VG.fromList originalVector
+                                let vecSource = slice (Strided (targetOffset, Length (length * sourceStride)) sourceStride) vecOriginal
+                                let vecTarget = slice (Strided (sourceOffset, Length (length * targetStride)) targetStride) vecOriginal
+                                -- MVG.set vecTarget 0
+                                --
+                                vecSourceLst' <- mvecToList vecSource
+
+                                --
+                                MVG.basicUnsafeMove vecTarget vecSource
+                                --
+                                vecSource' <- VG.unsafeFreeze vecSource
+                                vecTarget' <- VG.unsafeFreeze vecTarget
+                                vecOriginal' <- VG.unsafeFreeze vecOriginal
+                                pure (originalVector, vecSourceLst', vecOriginal', vecSource', vecTarget')
+                        {-
+                        putStrLn "~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                        print vecOriginal'
+                        print vecSourceLst
+                        print vecCarrier
+                        print vecSource
+                        print vecTarget
+                        -}
+                        -- 2. check that carrier is good-modified
+                        let prefix =    "(sourceTargetOffset = " ++ show sourceTargetOffset ++ ", "
+                                     ++ "sourceStride = " ++ show sourceStride ++ ", "
+                                     ++ "targetStride = " ++ show targetStride ++ ") "
+                        let initTarget = targetOffset + sourceTargetOffset
+                            modifiedIndexes = take length [initTarget, initTarget + targetStride..]
+                        assertBool
+                            (prefix ++ "All carrier vector values (except modified in target vector) should be the same")
+                            (all (\(idx, orig, carr) -> orig == carr || idx `elem` modifiedIndexes)
+                                 (zip3 [0..] vecOriginal' (VG.toList vecCarrier))
+                            )
+                        -- 1. check that target is good
+                        assertEqual (prefix ++ "Target is OK") vecSourceLst (VG.toList vecTarget)
+        -- pure ()
 
   ]
+
+
+
+
+
+
+
+
 

--- a/vecvec-lapack/tests/TST/Memory.hs
+++ b/vecvec-lapack/tests/TST/Memory.hs
@@ -1,174 +1,59 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE RecordWildCards    #-}
--- |
 module TST.Memory (tests) where
 
-import Control.Monad
-import Data.Typeable
-import Data.Foldable
-import Data.Traversable
-import Test.Tasty
-import Test.Tasty.QuickCheck
+
+import           Control.Monad.ST
+import           Data.Foldable                         (for_)
+import qualified Data.Vector.Generic                   as VG
+import qualified Data.Vector.Generic.Mutable           as MVG
+
+import           Vecvec.Classes.Slice
+import qualified Vecvec.LAPACK                         as VV
+import           Vecvec.LAPACK.Internal.Vector.Mutable (Strided (..))
+
 import           Test.Tasty
-import           Test.Tasty.HUnit as T
-
-import Data.Vector.Generic   qualified as VG
-import Data.Vector           qualified as V
-import Data.Vector.Unboxed   qualified as VU
-import Data.Vector.Storable  qualified as VS
-import Data.Vector.Primitive qualified as VP
-import Data.Vector.Generic.Mutable  qualified as MVG
-import Vecvec.LAPACK.Internal.Vector.Mutable qualified as MVGX
-import Data.Vector.Generic  qualified as VG
-
-import Vecvec.Classes.Slice
-import Vecvec.LAPACK         qualified as VV
-import Vecvec.LAPACK.Internal.Vector.Mutable (Strided(..))
-import Foreign.Ptr
--- import Vecvec.LAPACK.Internal.Compat
-import GHC.ForeignPtr        (ForeignPtr(..))
-import Data.Primitive.Ptr    (Ptr(..))
-import Foreign.Storable
-import Control.Monad.ST
-
-
-getPtr :: ForeignPtr a -> Ptr a
-{-# INLINE getPtr #-}
-getPtr (ForeignPtr addr _) = Ptr addr
-
-
-distancePtr :: forall a . Storable a => Ptr a -> Ptr a -> Int
--- distancePtr ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` (sizeOf (undefined :: a))
-distancePtr = distancePtr' undefined -- TODO WTF?? why ambigous??
- where
-    distancePtr' :: Storable a => a -> Ptr a -> Ptr a -> Int
-    distancePtr' x ptrFrom ptrTo = (ptrTo `minusPtr` ptrFrom) `div` sizeOf x
-
-assertArrays :: (VS.Storable a, Eq a, Show a) => VV.Vec a -> [a] -> VV.Vec a -> [a] -> VV.Vec a -> [a] -> IO ()
-assertArrays givenV1 expectedV1 givenV2 expectedV2 givenV3 expectedV3 = do
-  assertEqual "V1" (VG.fromList expectedV1) givenV1
-  assertEqual "V2" (VG.fromList expectedV2) givenV2
-  assertEqual "V3" (VG.fromList expectedV3) givenV3
+import           Test.Tasty.HUnit
 
 
 tests :: TestTree
 tests = testGroup "memory"
-  [ testCase "simple" $ do
-        --
-        -- TODO check also with **strided** vectors! -- via properties!!
-        --
-        -- let (vec :: VV.MVec MVG.RealWorld Int)  = runST $ MVG.basicUnsafeReplicate 10 123
-        let (vecCarrier :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int)  = runST $ do
-                    -- vec <- MVG.basicUnsafeReplicate 10 123
-                    vec <- MVG.generateM 20 (pure . (+10)) -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
-                    let v1 = MVG.slice 0 10 vec            -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-                    let v2 = MVG.slice 5 10 vec            --                     [15, 16, 17, 18, 19, 20, 21, 22, 23, 14]
-                    -- vec2 <- MVG.basicUnsafeReplicate 10 321
-                    -- MVG.basicUnsafeMove v1 {-target-} v2 {-source-} -- OK
-                    MVG.basicUnsafeMove v2 {-target-} v1 {-source-}
-                                                           -- [10, 11, 12, 13, 14, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 25, 26, 27, 28, 29]
-                    --
-                    vecf <- VG.freeze vec
-                    v1f  <- VG.freeze v1
-                    v2f  <- VG.freeze v2
-                    pure (vecf, v1f, v2f)
-
-        --print vecCarrier
-        --print vecSlice1
-        --print vecSlice2
-
-        assertArrays vecCarrier [10,11,12,13,14,10,11,12,13,14,15,16,17,18,19,25,26,27,28,29]
-                     vecSlice1  [10,11,12,13,14,10,11,12,13,14]
-                     vecSlice2  [10,11,12,13,14,15,16,17,18,19]
-  , testCase "intersected with stride" $ do
-        let (vecCarrier :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int, d, d2)  = runST $ do
-                    vec <- MVG.generateM 10 (pure . (+10)) -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-                    let vec1 = slice (Strided (0, End) 2) vec
-                    let vec2 = slice (2, Length 5) vec
-                    let MVGX.MVec vec1repr = vec1
-                        MVGX.MVec vec2repr = vec2
-                        vb1 = MVGX.vecBuffer vec1repr
-                        vb2 = MVGX.vecBuffer vec2repr
-                        diff = minusPtr (getPtr vb2) (getPtr vb1)
-                        diff2 = distancePtr (getPtr vb1) (getPtr vb2)
-                    MVG.basicUnsafeMove vec2 {-target-} vec1 {-source-}
-                    (,,,,) <$> VG.freeze vec <*> VG.freeze vec1 <*> VG.freeze vec2 <*> pure diff <*> pure diff2
-
-        --print vecCarrier
-        --print vecSlice1
-        --print vecSlice2
-
-        --putStrLn "***********"
-        --print d
-        --print d2
-        --putStrLn "^^^^^^^^^^^"
-        --                      [10,11,12,13,14,15,16,17,18,19
-        assertArrays vecCarrier [10,11,10,12,14,16,18,17,18,19]
-                                    -- ^^^^^----^^^^^ reinserted part
-                     vecSlice1  [10,   10,   14,   18,   18]
-                     vecSlice2        [10,12,14,16,18]
-  , testCase "options" $ do
-        let carrierLength = 200
-            -- length = 10
-        let targetOffset = 10
-            mvecToList vec = MVG.foldr' (:) [] vec
-        for_ [1..10] $ \length ->
-            for_ [-5,-4..5] $ \sourceTargetOffset ->
-                for_ [1..10] $ \sourceStride ->
-                    for_ [1..10] $ \targetStride -> do
-                        let (vecOriginal' :: [Int], vecSourceLst :: [Int], vecCarrier :: VV.Vec Int, vecSource :: VV.Vec Int, vecTarget :: VV.Vec Int) = runST $ do
-                                let sourceOffset = targetOffset + sourceTargetOffset
-                                let originalVector = [10 .. (10 + carrierLength - 1)]
-                                -- vecOriginal <- MVG.generateM carrierLength (pure . (+10))
-                                vecOriginal <- MVG.generateM carrierLength (\i -> pure $ originalVector !! i)
-                                -- let vecOriginal = VG.fromList originalVector
-                                let vecSource = slice (Strided (targetOffset, Length (length * sourceStride)) sourceStride) vecOriginal
-                                let vecTarget = slice (Strided (sourceOffset, Length (length * targetStride)) targetStride) vecOriginal
-                                -- MVG.set vecTarget 0
-                                --
-                                vecSourceLst' <- mvecToList vecSource
-
-                                --
-                                MVG.basicUnsafeMove vecTarget vecSource
-                                --
-                                vecSource' <- VG.unsafeFreeze vecSource
-                                vecTarget' <- VG.unsafeFreeze vecTarget
-                                vecOriginal' <- VG.unsafeFreeze vecOriginal
-                                pure (originalVector, vecSourceLst', vecOriginal', vecSource', vecTarget')
-                        {-
-                        putStrLn "~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                        print vecOriginal'
-                        print vecSourceLst
-                        print vecCarrier
-                        print vecSource
-                        print vecTarget
-                        -}
-                        -- 2. check that carrier is good-modified
-                        let prefix =    "(sourceTargetOffset = " ++ show sourceTargetOffset ++ ", "
+  [ testGroup "basicUnsafeMove"
+    [ testCase "miscellaneous intersections" $ do
+        let carrierLength   = 200
+        let sourceOffset    = 30
+        let carrierOriginal = [1..carrierLength]
+        for_ [1..10] $ \sourceLength ->
+          for_ [-5,-4..5] $ \sourceTargetOffset ->
+            for_ [1..10] $ \sourceStride ->
+              for_ [1..10] $ \targetStride -> do
+                let targetLength    = sourceLength
+                let (sourceOriginal :: [Int], carrierResult:: VV.Vec Int, targetResult :: VV.Vec Int) = runST $ do
+                      carrier          <- MVG.generateM carrierLength (pure . (carrierOriginal !!))
+                      let targetOffset =  sourceOffset + sourceTargetOffset
+                      let source       =  slice (Strided (sourceOffset, Length (sourceLength * sourceStride)) sourceStride) carrier
+                      let target       =  slice (Strided (targetOffset, Length (targetLength * targetStride)) targetStride) carrier
+                      sourceOriginal'  <- MVG.foldr' (:) [] source
+                      --
+                      MVG.basicUnsafeMove target source
+                      --
+                      target'  <- VG.unsafeFreeze target
+                      carrier' <- VG.unsafeFreeze carrier
+                      pure (sourceOriginal', carrier', target')
+                let caseNamePrefix =    "(sourceTargetOffset = " ++ show sourceTargetOffset ++ ", "
                                      ++ "sourceStride = " ++ show sourceStride ++ ", "
                                      ++ "targetStride = " ++ show targetStride ++ ") "
-                        let initTarget = targetOffset + sourceTargetOffset
-                            modifiedIndexes = take length [initTarget, initTarget + targetStride..]
-                        assertBool
-                            (prefix ++ "All carrier vector values (except modified in target vector) should be the same")
-                            (all (\(idx, orig, carr) -> orig == carr || idx `elem` modifiedIndexes)
-                                 (zip3 [0..] vecOriginal' (VG.toList vecCarrier))
-                            )
-                        -- 1. check that target is good
-                        assertEqual (prefix ++ "Target is OK") vecSourceLst (VG.toList vecTarget)
-        -- pure ()
-
+                -- 1. check that carrier is not modified on non-target places
+                let initTargetIndex = sourceOffset + sourceTargetOffset
+                let modifiedIndexes = take targetLength [initTargetIndex, initTargetIndex + targetStride..]
+                assertBool
+                  (caseNamePrefix ++ "All carrier vector values (except modified in target vector) should be the same")
+                  (all (\(idx, orig, carr) -> orig == carr || idx `elem` modifiedIndexes)
+                       (zip3 [0..] carrierOriginal (VG.toList carrierResult))
+                  )
+                -- 2. check that target is a copy of the source
+                assertEqual
+                  (caseNamePrefix ++ "Target is a copy of the source")
+                  sourceOriginal
+                  (VG.toList targetResult)
+      ]
   ]
-
-
-
-
-
-
-
-
 

--- a/vecvec-lapack/tests/TST/Memory.hs
+++ b/vecvec-lapack/tests/TST/Memory.hs
@@ -26,15 +26,21 @@ import Vecvec.LAPACK.Internal.Vector.Mutable (Strided(..))
 
 import Control.Monad.ST
 
+assertArrays :: (VS.Storable a, Eq a, Show a) => VV.Vec a -> [a] -> VV.Vec a -> [a] -> VV.Vec a -> [a] -> IO ()
+assertArrays givenV1 expectedV1 givenV2 expectedV2 givenV3 expectedV3 = do
+  assertEqual "V1" givenV1 (VG.fromList expectedV1)
+  assertEqual "V2" givenV2 (VG.fromList expectedV2)
+  assertEqual "V3" givenV3 (VG.fromList expectedV3)
+
+
 tests :: TestTree
 tests = testGroup "memory"
   [ testCase "simple" $ do
-        putStrLn "UPS"
         --
         -- TODO check also with **strided** vectors! -- via properties!!
         --
         -- let (vec :: VV.MVec MVG.RealWorld Int)  = runST $ MVG.basicUnsafeReplicate 10 123
-        let (vecOrig :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int)  = runST $ do
+        let (vecCarrier :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int)  = runST $ do
                     -- vec <- MVG.basicUnsafeReplicate 10 123
                     vec <- MVG.generateM 20 (pure . (+10)) -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
                     let v1 = MVG.slice 0 10 vec            -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -48,9 +54,31 @@ tests = testGroup "memory"
                     v1f  <- VG.freeze v1
                     v2f  <- VG.freeze v2
                     pure (vecf, v1f, v2f)
-        print vecOrig
-        print vecSlice1
-        print vecSlice2
-        pure ()
+
+        --print vecCarrier
+        --print vecSlice1
+        --print vecSlice2
+
+        assertArrays vecCarrier [10,11,12,13,14,10,11,12,13,14,15,16,17,18,19,25,26,27,28,29]
+                     vecSlice1  [10,11,12,13,14,10,11,12,13,14]
+                     vecSlice2  [10,11,12,13,14,15,16,17,18,19]
+  , testCase "intersected with stride" $ do
+        let (vecCarrier :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int)  = runST $ do
+                    vec <- MVG.generateM 10 (pure . (+10)) -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+                    let vec1 = slice (Strided (0, End) 2) vec
+                    let vec2 = slice (2, Length 5) vec
+                    MVG.basicUnsafeMove vec2 {-target-} vec1 {-source-}
+                    (,,) <$> VG.freeze vec <*> VG.freeze vec1 <*> VG.freeze vec2
+
+        --print vecCarrier
+        --print vecSlice1
+        --print vecSlice2
+
+        --                      [10,11,12,13,14,15,16,17,18,19
+        assertArrays vecCarrier [10,11,10,12,14,16,18,17,18,19]
+                                    -- ^^^^^^^^^^^^^^ reinserted part
+                     vecSlice1  [10,   10,   14,   18,   18]
+                     vecSlice2        [10,12,14,16,18]
+
   ]
 

--- a/vecvec-lapack/tests/TST/Memory.hs
+++ b/vecvec-lapack/tests/TST/Memory.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+-- |
+module TST.Memory (tests) where
+
+import Data.Typeable
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.HUnit as T
+
+import Data.Vector.Generic   qualified as VG
+import Data.Vector           qualified as V
+import Data.Vector.Unboxed   qualified as VU
+import Data.Vector.Storable  qualified as VS
+import Data.Vector.Primitive qualified as VP
+import Data.Vector.Generic.Mutable  qualified as MVG
+import Data.Vector.Generic  qualified as VG
+
+import Vecvec.Classes.Slice
+import Vecvec.LAPACK         qualified as VV
+import Vecvec.LAPACK.Internal.Vector.Mutable (Strided(..))
+
+import Control.Monad.ST
+
+tests :: TestTree
+tests = testGroup "memory"
+  [ testCase "simple" $ do
+        putStrLn "UPS"
+        --
+        -- TODO check also with **strided** vectors! -- via properties!!
+        --
+        -- let (vec :: VV.MVec MVG.RealWorld Int)  = runST $ MVG.basicUnsafeReplicate 10 123
+        let (vecOrig :: VV.Vec Int, vecSlice1 :: VV.Vec Int, vecSlice2 :: VV.Vec Int)  = runST $ do
+                    -- vec <- MVG.basicUnsafeReplicate 10 123
+                    vec <- MVG.generateM 20 (pure . (+10)) -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+                    let v1 = MVG.slice 0 10 vec            -- [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+                    let v2 = MVG.slice 5 10 vec            --                     [15, 16, 17, 18, 19, 20, 21, 22, 23, 14]
+                    -- vec2 <- MVG.basicUnsafeReplicate 10 321
+                    -- MVG.basicUnsafeMove v1 {-target-} v2 {-source-} -- OK
+                    MVG.basicUnsafeMove v2 {-target-} v1 {-source-}
+                                                           -- [10, 11, 12, 13, 14, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 25, 26, 27, 28, 29]
+                    --
+                    vecf <- VG.freeze vec
+                    v1f  <- VG.freeze v1
+                    v2f  <- VG.freeze v2
+                    pure (vecf, v1f, v2f)
+        print vecOrig
+        print vecSlice1
+        print vecSlice2
+        pure ()
+  ]
+

--- a/vecvec-lapack/tests/TST/Memory.hs
+++ b/vecvec-lapack/tests/TST/Memory.hs
@@ -20,15 +20,16 @@ tests = testGroup "memory"
     [ testCase "miscellaneous intersections" $ do
         let carrierLength = 200
         let sourceOffset  = 30
-        for_ [1..10] $ \sourceLength ->
+        for_ [1..10] $ \len ->
           for_ [-5,-4..5] $ \sourceTargetOffset ->
             for_ [1..10] $ \sourceStride ->
               for_ [1..10] $ \targetStride -> do
-                let targetLength = sourceLength
+                let caseNamePrefix = "(sourceTargetOffset = " ++ show sourceTargetOffset ++ ", "
+                                  ++ "sourceStride = " ++ show sourceStride ++ ", "
+                                  ++ "targetStride = " ++ show targetStride ++ ") "
                 let targetOffset = sourceOffset + sourceTargetOffset
-                let caseNamePrefix =    "(sourceTargetOffset = " ++ show sourceTargetOffset ++ ", "
-                                     ++ "sourceStride = " ++ show sourceStride ++ ", "
-                                     ++ "targetStride = " ++ show targetStride ++ ") "
+                    sliceSrc     = (sourceOffset, Length (len * sourceStride)) `Strided` sourceStride
+                    sliceTgt     = (targetOffset, Length (len * targetStride)) `Strided` targetStride
                 -- According to specification of `move`,
                 -- "If the vectors do not overlap, then this is equivalent to copy.
                 -- Otherwise, the copying is performed as if the source vector were
@@ -38,17 +39,17 @@ tests = testGroup "memory"
                 -- after using the intermediate buffer for copying -- the results should match.
                 let (carrier1', carrier2', target1', target2' :: VV.Vec Int) = runST $ do
                       carrier1    <- MVG.generateM carrierLength pure
-                      let source1 =  slice (Strided (sourceOffset, Length (sourceLength * sourceStride)) sourceStride) carrier1
-                      let target1 =  slice (Strided (targetOffset, Length (targetLength * targetStride)) targetStride) carrier1
-                      MVG.basicUnsafeMove target1 source1
+                      let source1 = slice sliceSrc carrier1
+                      let target1 = slice sliceTgt carrier1
+                      MVG.move target1 source1
                       --
                       carrier2    <- MVG.generateM carrierLength pure
-                      let source2 =  slice (Strided (sourceOffset, Length (sourceLength * sourceStride)) sourceStride) carrier2
-                      let target2 =  slice (Strided (targetOffset, Length (targetLength * targetStride)) targetStride) carrier2
+                      let source2 = slice sliceSrc carrier2
+                      let target2 = slice sliceTgt carrier2
                       tmp <- MVG.clone source2
-                      MVG.basicUnsafeCopy target2 tmp
+                      MVG.copy target2 tmp
                       --
-                      (,,,) <$> VG.unsafeFreeze target1 <*> VG.unsafeFreeze target2 <*> VG.unsafeFreeze carrier1 <*> VG.unsafeFreeze carrier2
+                      (,,,) <$> VG.freeze target1 <*> VG.freeze target2 <*> VG.freeze carrier1 <*> VG.freeze carrier2
                 assertEqual (caseNamePrefix ++  "Carrier vectors should be the same") carrier1' carrier2'
                 assertEqual (caseNamePrefix ++  "Target vectors should be the same")  target1'  target2'
       ]

--- a/vecvec-lapack/tests/TST/Memory.hs
+++ b/vecvec-lapack/tests/TST/Memory.hs
@@ -6,7 +6,7 @@ import           Data.Foldable                         (for_)
 import qualified Data.Vector.Generic                   as VG
 import qualified Data.Vector.Generic.Mutable           as MVG
 
-import           Vecvec.Classes.Slice
+import           Vecvec.Classes.NDArray                (Length (..), slice)
 import qualified Vecvec.LAPACK                         as VV
 import           Vecvec.LAPACK.Internal.Vector.Mutable (Strided (..))
 

--- a/vecvec-lapack/tests/main.hs
+++ b/vecvec-lapack/tests/main.hs
@@ -6,6 +6,7 @@ import qualified TST.VectorSpace
 import qualified TST.Decomposition
 import qualified TST.LinSolve
 import qualified TST.MatDense
+import qualified TST.Memory
 
 main :: IO ()
 main = defaultMain $ testGroup "vecvec"
@@ -16,4 +17,5 @@ main = defaultMain $ testGroup "vecvec"
   , TST.MatMul.tests
   , TST.Decomposition.tests
   , TST.LinSolve.tests
+  , TST.Memory.tests
   ]

--- a/vecvec-lapack/vecvec-lapack.cabal
+++ b/vecvec-lapack/vecvec-lapack.cabal
@@ -59,14 +59,9 @@ test-suite vecvec-lapack-tests
                     TST.MatMul
                     TST.MatDense
                     TST.Slice
-                    TST.Tools.Model
-                    TST.Tools.MatModel
-                    TST.Tools.Orphanage
-                    TST.Tools.Util
-                    TST.Vector.Boilerplater
-                    TST.Vector.Property
-                    TST.Vector.Utilities
-                    TST.VectorSpace
+                    TST.Orphanage
+                    TST.Property
+                    TST.Memory
   default-extensions: FlexibleContexts
                       ImportQualifiedPost
                       RankNTypes
@@ -85,6 +80,7 @@ test-suite vecvec-lapack-tests
                     , random
                     , tasty            >= 1.2
                     , tasty-quickcheck >= 0.10
+                    , tasty-hunit
                     , template-haskell
                     , transformers
 

--- a/vecvec-lapack/vecvec-lapack.cabal
+++ b/vecvec-lapack/vecvec-lapack.cabal
@@ -59,8 +59,14 @@ test-suite vecvec-lapack-tests
                     TST.MatMul
                     TST.MatDense
                     TST.Slice
-                    TST.Orphanage
-                    TST.Property
+                    TST.Tools.Model
+                    TST.Tools.MatModel
+                    TST.Tools.Orphanage
+                    TST.Tools.Util
+                    TST.Vector.Boilerplater
+                    TST.Vector.Property
+                    TST.Vector.Utilities
+                    TST.VectorSpace
                     TST.Memory
   default-extensions: FlexibleContexts
                       ImportQualifiedPost


### PR DESCRIPTION
Implementation for `basicUnsafeMove` and my own test for this -- it just goes through all the offset/stride/length options of source/target vectors. Arbitrary tests from `vector` package still not adopted.

Please review.



