### PR TITLE
Change kind of HasShape and NDArray type classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,15 @@ jobs:
       matrix:
         include:
           - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.2.8"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.4.6"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.4.7"  }
           - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.2"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.8.1"  }
       fail-fast: false
     steps:
     # ----------------
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # ----------------
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -35,7 +36,7 @@ jobs:
     - name: "openblas"
       run:  "sudo apt-get install libopenblas-dev liblapack-dev liblapacke-dev"
     # ----------------
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/vecvec-classes/Vecvec/Classes.hs
+++ b/vecvec-classes/Vecvec/Classes.hs
@@ -202,17 +202,19 @@ class ( VectorSpace a
 infixl 7 @@
 
 -- | Newtype for passing matrix\/vector to '@@' as transposed.
-newtype Tr a = Tr { getTr :: a }
+newtype Tr v a = Tr { getTr :: v a }
   deriving stock   (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
   deriving newtype (AdditiveSemigroup,AdditiveMonoid,AdditiveQuasigroup,VectorSpace,InnerSpace)
 
 -- | Newtype for passing matrix\/vector to '@@' as conjugated.
-newtype Conj a = Conj { getConj :: a }
+newtype Conj v a = Conj { getConj :: v a }
   deriving stock   (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
   deriving newtype (AdditiveSemigroup,AdditiveMonoid,AdditiveQuasigroup,VectorSpace,InnerSpace)
 
-instance Eq1 Tr   where liftEq = coerce
-instance Eq1 Conj where liftEq = coerce
+instance Eq1 v => Eq1 (Tr v) where
+  liftEq f (Tr a) (Tr b) = liftEq f a b
+instance Eq1 v => Eq1 (Conj v) where
+  liftEq f (Conj a) (Conj b) = liftEq f a b
 
 
 ----------------------------------------------------------------
@@ -448,6 +450,7 @@ instance RealFloat a => NormedScalar (Complex a) where
   conjugate = Complex.conjugate
   scalarNormSq (r1 :+ i1) = r1*r1 + i1*i1
   fromR x = x :+ 0
+
 
 ----------------------------------------------------------------
 -- zipWith which errors when vector have different length

--- a/vecvec-classes/Vecvec/Classes.hs
+++ b/vecvec-classes/Vecvec/Classes.hs
@@ -431,57 +431,6 @@ deriving via (AsFixedVec (F.ContVec n) a) instance (F.Arity n, Num a)          =
 deriving via (AsFixedVec (F.ContVec n) a) instance (F.Arity n, NormedScalar a) => InnerSpace         (F.ContVec n a)
 
 
-instance (Num a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n
-         ) => MatMul (Tr (FB.Vec n a)) (FB.Vec n b) a where
-  Tr v @@ u = F.sum $ F.zipWith (*) v u
-  {-# INLINE (@@) #-}
-
-instance (Num a, VectorSpace a, Scalar a ~ a, a ~ b, FU.Unbox n a
-         ) => MatMul (Tr (FU.Vec n a)) (FU.Vec n b) a where
-  Tr v @@ u = F.sum $ F.zipWith (*) v u
-  {-# INLINE (@@) #-}
-
-instance (Num a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n, FS.Storable a
-         ) => MatMul (Tr (FS.Vec n a)) (FS.Vec n b) a where
-  Tr v @@ u = F.sum $ F.zipWith (*) v u
-  {-# INLINE (@@) #-}
-
-instance (Num a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n, FP.Prim a
-         ) => MatMul (Tr (FP.Vec n a)) (FP.Vec n b) a where
-  Tr v @@ u = F.sum $ F.zipWith (*) v u
-  {-# INLINE (@@) #-}
-
-instance (Num a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n
-         ) => MatMul (Tr (F.ContVec n a)) (F.ContVec n b) a where
-  Tr v @@ u = F.sum $ F.zipWith (*) v u
-  {-# INLINE (@@) #-}
-
-instance (NormedScalar a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n
-         ) => MatMul (Conj (FB.Vec n a)) (FB.Vec n b) a where
-  Conj v @@ u = F.sum $ F.zipWith (\a b -> conjugate a * b) v u
-  {-# INLINE (@@) #-}
-
-instance (NormedScalar a, VectorSpace a, Scalar a ~ a, a ~ b, FU.Unbox n a
-         ) => MatMul (Conj (FU.Vec n a)) (FU.Vec n b) a where
-  Conj v @@ u = F.sum $ F.zipWith (\a b -> conjugate a * b) v u
-  {-# INLINE (@@) #-}
-
-instance (NormedScalar a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n, FS.Storable a
-         ) => MatMul (Conj (FS.Vec n a)) (FS.Vec n b) a where
-  Conj v @@ u = F.sum $ F.zipWith (\a b -> conjugate a * b) v u
-  {-# INLINE (@@) #-}
-
-instance (NormedScalar a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n, FP.Prim a
-         ) => MatMul (Conj (FP.Vec n a)) (FP.Vec n b) a where
-  Conj v @@ u = F.sum $ F.zipWith (\a b -> conjugate a * b) v u
-  {-# INLINE (@@) #-}
-
-instance (NormedScalar a, VectorSpace a, Scalar a ~ a, a ~ b, F.Arity n
-         ) => MatMul (Conj (F.ContVec n a)) (F.ContVec n b) a where
-  Conj v @@ u = F.sum $ F.zipWith (\a b -> conjugate a * b) v u
-  {-# INLINE (@@) #-}
-
-
 instance NormedScalar Float where
   type R Float = Float
   conjugate = id

--- a/vecvec-hmatrix/Vecvec/HMatrix.hs
+++ b/vecvec-hmatrix/Vecvec/HMatrix.hs
@@ -37,30 +37,30 @@ instance (Num a, Element a) => VectorSpace (Matrix a) where
 instance (a ~ b, Num a, Numeric a) => MatMul (Matrix a) (Matrix b) (Matrix a) where
   (@@) = (HM.<>)
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Tr (Matrix a)) (Matrix b) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Tr Matrix a) (Matrix b) (Matrix a) where
   Tr a @@ b = tr a HM.<> b
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Conj (Matrix a)) (Matrix b) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Conj Matrix a) (Matrix b) (Matrix a) where
   Conj a @@ b = tr' a HM.<> b
 
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Matrix a) (Tr (Matrix b)) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Matrix a) (Tr Matrix b) (Matrix a) where
   a @@ Tr b = a HM.<> tr b
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Tr (Matrix a)) (Tr (Matrix b)) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Tr Matrix a) (Tr Matrix b) (Matrix a) where
   Tr a @@ Tr b = tr a HM.<> tr b
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Conj (Matrix a)) (Tr (Matrix b)) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Conj Matrix a) (Tr Matrix b) (Matrix a) where
   Conj a @@ Tr b = tr' a HM.<> tr b
 
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Matrix a) (Conj (Matrix b)) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Matrix a) (Conj Matrix b) (Matrix a) where
   a @@ Conj b = a HM.<> tr' b
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Tr (Matrix a)) (Conj (Matrix b)) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Tr Matrix a) (Conj Matrix b) (Matrix a) where
   Tr a @@ Conj b = tr a HM.<> tr' b
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Conj (Matrix a)) (Conj (Matrix b)) (Matrix a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Conj Matrix a) (Conj Matrix b) (Matrix a) where
   Conj a @@ Conj b = tr' a HM.<> tr' b
 
 
@@ -70,14 +70,14 @@ instance (a ~ b, Num a, Numeric a) => MatMul (Conj (Matrix a)) (Conj (Matrix b))
 instance (a ~ b, Num a, Numeric a) => MatMul (Matrix a) (Vector b) (Vector a) where
   (@@) = (HM.#>)
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Tr (Matrix a)) (Vector b) (Vector a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Tr Matrix a) (Vector b) (Vector a) where
   Tr m @@ v = tr m HM.#> v
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Conj (Matrix a)) (Vector b) (Vector a) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Conj Matrix a) (Vector b) (Vector a) where
   Conj m @@ v = tr' m HM.#> v
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Tr (Vector a)) (Matrix b) (Tr (Vector a)) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Tr Vector a) (Matrix b) (Tr Vector a) where
   Tr v @@ m = Tr (tr m #> v)
 
-instance (a ~ b, Num a, Numeric a) => MatMul (Conj (Vector a)) (Matrix b) (Conj (Vector a)) where
+instance (a ~ b, Num a, Numeric a) => MatMul (Conj Vector a) (Matrix b) (Conj Vector a) where
   Conj v @@ m = Conj (tr' m #> v)

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Dense.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Dense.hs
@@ -91,14 +91,13 @@ instance M.AsMInput s Matrix where
   {-# INLINE asMInput #-}
   asMInput = coerce
 
+type instance NDim Matrix = 2
 
-instance HasShape (Matrix a) where
-  type instance NDim (Matrix a) = 2
+instance HasShape Matrix a where
   shapeAsCVec (Matrix M.MView{..}) = FC.mk2 nrows ncols
   {-# INLINE shapeAsCVec #-}
 
-instance Storable a => NDArray (Matrix a) where
-  type Elt (Matrix a) = a
+instance Storable a => NDArray Matrix a where
   {-# INLINE unsafeIndexCVec #-}
   unsafeIndexCVec (Matrix M.MView{..}) (FC.ContVec cont) = cont $ FC.Fun $ \i j -> do
     unsafeInlineIO
@@ -180,7 +179,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Vec a') (Vec a) where
     M.unsafeBlasGemv C.NoTrans 1 mat vecX 0 vecY
     VG.unsafeFreeze vecY
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Vec a') (Vec a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Tr Matrix a) (Vec a') (Vec a) where
   Tr m @@ v
     | nRows m /= VG.length v = error "matrix size mismatch"
   Tr mat @@ vecX = unsafePerformIO $ do
@@ -188,7 +187,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Vec a') (Vec a) where
     M.unsafeBlasGemv C.Trans 1 mat vecX 0 vecY
     VG.unsafeFreeze vecY
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Conj (Matrix a)) (Vec a') (Vec a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Conj Matrix a) (Vec a') (Vec a) where
   Conj m @@ v
     | nRows m /= VG.length v = error "matrix size mismatch"
   Conj mat @@ vecX = unsafePerformIO $ do
@@ -215,7 +214,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Matrix a') (Matrix a) where
       n' = nRows matB
       k  = nCols matB
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Matrix a') (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Tr Matrix a) (Matrix a') (Matrix a) where
   Tr matA @@ matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -228,7 +227,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Matrix a') (Matrix a) 
       n' = nRows matB
       k  = nCols matB
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Conj (Matrix a)) (Matrix a') (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Conj Matrix a) (Matrix a') (Matrix a) where
   Conj matA @@ matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -243,7 +242,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Conj (Matrix a)) (Matrix a') (Matrix a
 
 
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Tr (Matrix a')) (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Tr Matrix a') (Matrix a) where
   matA @@ Tr matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -256,7 +255,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Tr (Matrix a')) (Matrix a) 
       k  = nRows matB
       n' = nCols matB
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Tr (Matrix a')) (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Tr Matrix a) (Tr Matrix a') (Matrix a) where
   Tr matA @@ Tr matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -269,7 +268,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Tr (Matrix a')) (Matri
       k  = nRows matB
       n' = nCols matB
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Conj (Matrix a)) (Tr (Matrix a')) (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Conj Matrix a) (Tr Matrix a') (Matrix a) where
   Conj matA @@ Tr matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -283,7 +282,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Conj (Matrix a)) (Tr (Matrix a')) (Mat
       n' = nCols matB
 
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Conj (Matrix a')) (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Conj Matrix a') (Matrix a) where
   matA @@ Conj matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -296,7 +295,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Matrix a) (Conj (Matrix a')) (Matrix a
       k  = nRows matB
       n' = nCols matB
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Conj (Matrix a')) (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Tr Matrix a) (Conj Matrix a') (Matrix a) where
   Tr matA @@ Conj matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do
@@ -309,7 +308,7 @@ instance (C.LAPACKy a, a ~ a') => MatMul (Tr (Matrix a)) (Conj (Matrix a')) (Mat
       k  = nRows matB
       n' = nCols matB
 
-instance (C.LAPACKy a, a ~ a') => MatMul (Conj (Matrix a)) (Conj (Matrix a')) (Matrix a) where
+instance (C.LAPACKy a, a ~ a') => MatMul (Conj Matrix a) (Conj Matrix a') (Matrix a) where
   Conj matA @@ Conj matB
     | n /= n'   = error "Matrix size mismatch"
     | otherwise = unsafePerformIO $ do

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Dense/Mutable.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Dense/Mutable.hs
@@ -122,8 +122,9 @@ newtype MMatrix s a = MMatrix (MView a)
 
 deriving newtype instance (Slice1D i, Slice1D j, Storable a) => Slice (i,j) (MMatrix s a)
 
-instance HasShape (MMatrix s a) where
-  type NDim (MMatrix s a) = 2
+type instance NDim (MMatrix s) = 2
+
+instance HasShape (MMatrix s) a where
   shapeAsCVec (MMatrix MView{..}) = FC.mk2 nrows ncols
   {-# INLINE shapeAsCVec #-}
 

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Vector/Mutable.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Vector/Mutable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -51,13 +52,13 @@ import Foreign.ForeignPtr
 import Foreign.Ptr
 import Foreign.Marshal.Array
 
+import Data.Vector.Fixed.Cont       qualified as FC
 import Data.Vector.Storable         qualified as VS
 import Data.Vector.Storable.Mutable qualified as MVS
 import Data.Vector.Generic.Mutable  qualified as MVG
 
 import Vecvec.Classes
 import Vecvec.Classes.NDArray
-import Vecvec.Classes.Via
 import Vecvec.LAPACK.FFI             (LAPACKy)
 import Vecvec.LAPACK.FFI             qualified as C
 import Vecvec.LAPACK.Utils
@@ -138,7 +139,14 @@ fromMVector (MVS.MVector len buf) = MVec (VecRepr len 1 buf)
 --   vector.
 data Strided a = Strided a !Int
 
-deriving via AsMVector MVec s a instance Storable a => HasShape (MVec s a)
+
+type instance NDim (MVec s) = 1
+
+instance Storable a => HasShape (MVec s) a where
+  shapeAsCVec = FC.mk1 . MVG.length
+  {-# INLINE shapeAsCVec #-}
+
+
 
 instance (i ~ Int, Storable a) => Slice (i, Length) (MVec s a) where
   {-# INLINE sliceMaybe #-}

--- a/vecvec-lapack/tests/TST/LinSolve.hs
+++ b/vecvec-lapack/tests/TST/LinSolve.hs
@@ -124,7 +124,7 @@ class ArbitraryRHS rhs a where
   arbitraryRHS :: SmallScalar a => Int -> Gen (rhs a)
   checkLinEq   :: Matrix a -> rhs a -> rhs a -> Property
 
-instance (VV.LAPACKy a, Epsilon (R a), Floating (R a), Ord (R a), Eq a
+instance (VV.LAPACKy a, Epsilon (R a), Floating (R a), Ord (R a)
          ) => ArbitraryRHS Matrix a where
   arbitraryRHS sz = do
     n <- choose (1,4)

--- a/vecvec-lapack/tests/TST/MatMul.hs
+++ b/vecvec-lapack/tests/TST/MatMul.hs
@@ -33,60 +33,60 @@ import TST.Tools.MatModel
 import TST.Tools.Util
 
 tests :: TestTree
-tests = testGroup "MatMul"
+tests = testGroup "MatMul" 
   [ -- Matrix-vector
-    prop_matmul @(Matrix S)        @(VV.Vec S) unMV
-  , prop_matmul @(Matrix D)        @(VV.Vec D) unMV
-  , prop_matmul @(Matrix C)        @(VV.Vec C) unMV
-  , prop_matmul @(Matrix Z)        @(VV.Vec Z) unMV
-  , prop_matmul @(Tr (Matrix S))   @(VV.Vec S) unMV
-  , prop_matmul @(Tr (Matrix D))   @(VV.Vec D) unMV
-  , prop_matmul @(Tr (Matrix C))   @(VV.Vec C) unMV
-  , prop_matmul @(Tr (Matrix Z))   @(VV.Vec Z) unMV
-  , prop_matmul @(Conj (Matrix S)) @(VV.Vec S) unMV
-  , prop_matmul @(Conj (Matrix D)) @(VV.Vec D) unMV
-  , prop_matmul @(Conj (Matrix C)) @(VV.Vec C) unMV
-  , prop_matmul @(Conj (Matrix Z)) @(VV.Vec Z) unMV
-    -- Matrix-matrix
-    -- 1.
-  , prop_matmul @(Matrix S)        @(Matrix S) unMM
-  , prop_matmul @(Matrix D)        @(Matrix D) unMM
-  , prop_matmul @(Matrix C)        @(Matrix C) unMM
-  , prop_matmul @(Matrix Z)        @(Matrix Z) unMM
-  , prop_matmul @(Tr (Matrix S))   @(Matrix S) unMM
-  , prop_matmul @(Tr (Matrix D))   @(Matrix D) unMM
-  , prop_matmul @(Tr (Matrix C))   @(Matrix C) unMM
-  , prop_matmul @(Tr (Matrix Z))   @(Matrix Z) unMM
-  , prop_matmul @(Conj (Matrix S)) @(Matrix S) unMM
-  , prop_matmul @(Conj (Matrix D)) @(Matrix D) unMM
-  , prop_matmul @(Conj (Matrix C)) @(Matrix C) unMM
-  , prop_matmul @(Conj (Matrix Z)) @(Matrix Z) unMM
-    -- 2.
-  , prop_matmul @(Matrix S)        @(Tr (Matrix S)) unMM
-  , prop_matmul @(Matrix D)        @(Tr (Matrix D)) unMM
-  , prop_matmul @(Matrix C)        @(Tr (Matrix C)) unMM
-  , prop_matmul @(Matrix Z)        @(Tr (Matrix Z)) unMM
-  , prop_matmul @(Tr (Matrix S))   @(Tr (Matrix S)) unMM
-  , prop_matmul @(Tr (Matrix D))   @(Tr (Matrix D)) unMM
-  , prop_matmul @(Tr (Matrix C))   @(Tr (Matrix C)) unMM
-  , prop_matmul @(Tr (Matrix Z))   @(Tr (Matrix Z)) unMM
-  , prop_matmul @(Conj (Matrix S)) @(Tr (Matrix S)) unMM
-  , prop_matmul @(Conj (Matrix D)) @(Tr (Matrix D)) unMM
-  , prop_matmul @(Conj (Matrix C)) @(Tr (Matrix C)) unMM
-  , prop_matmul @(Conj (Matrix Z)) @(Tr (Matrix Z)) unMM
-    -- 3.
-  , prop_matmul @(Matrix S)        @(Conj (Matrix S)) unMM
-  , prop_matmul @(Matrix D)        @(Conj (Matrix D)) unMM
-  , prop_matmul @(Matrix C)        @(Conj (Matrix C)) unMM
-  , prop_matmul @(Matrix Z)        @(Conj (Matrix Z)) unMM
-  , prop_matmul @(Tr (Matrix S))   @(Conj (Matrix S)) unMM
-  , prop_matmul @(Tr (Matrix D))   @(Conj (Matrix D)) unMM
-  , prop_matmul @(Tr (Matrix C))   @(Conj (Matrix C)) unMM
-  , prop_matmul @(Tr (Matrix Z))   @(Conj (Matrix Z)) unMM
-  , prop_matmul @(Conj (Matrix S)) @(Conj (Matrix S)) unMM
-  , prop_matmul @(Conj (Matrix D)) @(Conj (Matrix D)) unMM
-  , prop_matmul @(Conj (Matrix C)) @(Conj (Matrix C)) unMM
-  , prop_matmul @(Conj (Matrix Z)) @(Conj (Matrix Z)) unMM
+    prop_matmul @(Matrix S)      @(VV.Vec S) unMV
+  , prop_matmul @(Matrix D)      @(VV.Vec D) unMV
+  , prop_matmul @(Matrix C)      @(VV.Vec C) unMV
+  , prop_matmul @(Matrix Z)      @(VV.Vec Z) unMV
+  -- , prop_matmul @(Tr Matrix S)   @(VV.Vec S) unMV
+  -- , prop_matmul @(Tr Matrix D)   @(VV.Vec D) unMV
+  -- , prop_matmul @(Tr Matrix C)   @(VV.Vec C) unMV
+  -- , prop_matmul @(Tr Matrix Z)   @(VV.Vec Z) unMV
+  -- , prop_matmul @(Conj Matrix S) @(VV.Vec S) unMV
+  -- , prop_matmul @(Conj Matrix D) @(VV.Vec D) unMV
+  -- , prop_matmul @(Conj Matrix C) @(VV.Vec C) unMV
+  -- , prop_matmul @(Conj Matrix Z) @(VV.Vec Z) unMV
+--     -- Matrix-matrix
+--     -- 1.
+--   , prop_matmul @(Matrix S)        @(Matrix S) unMM
+--   , prop_matmul @(Matrix D)        @(Matrix D) unMM
+--   , prop_matmul @(Matrix C)        @(Matrix C) unMM
+--   , prop_matmul @(Matrix Z)        @(Matrix Z) unMM
+--   , prop_matmul @(Tr (Matrix S))   @(Matrix S) unMM
+--   , prop_matmul @(Tr (Matrix D))   @(Matrix D) unMM
+--   , prop_matmul @(Tr (Matrix C))   @(Matrix C) unMM
+--   , prop_matmul @(Tr (Matrix Z))   @(Matrix Z) unMM
+--   , prop_matmul @(Conj (Matrix S)) @(Matrix S) unMM
+--   , prop_matmul @(Conj (Matrix D)) @(Matrix D) unMM
+--   , prop_matmul @(Conj (Matrix C)) @(Matrix C) unMM
+--   , prop_matmul @(Conj (Matrix Z)) @(Matrix Z) unMM
+--     -- 2.
+--   , prop_matmul @(Matrix S)        @(Tr (Matrix S)) unMM
+--   , prop_matmul @(Matrix D)        @(Tr (Matrix D)) unMM
+--   , prop_matmul @(Matrix C)        @(Tr (Matrix C)) unMM
+--   , prop_matmul @(Matrix Z)        @(Tr (Matrix Z)) unMM
+--   , prop_matmul @(Tr (Matrix S))   @(Tr (Matrix S)) unMM
+--   , prop_matmul @(Tr (Matrix D))   @(Tr (Matrix D)) unMM
+--   , prop_matmul @(Tr (Matrix C))   @(Tr (Matrix C)) unMM
+--   , prop_matmul @(Tr (Matrix Z))   @(Tr (Matrix Z)) unMM
+--   , prop_matmul @(Conj (Matrix S)) @(Tr (Matrix S)) unMM
+--   , prop_matmul @(Conj (Matrix D)) @(Tr (Matrix D)) unMM
+--   , prop_matmul @(Conj (Matrix C)) @(Tr (Matrix C)) unMM
+--   , prop_matmul @(Conj (Matrix Z)) @(Tr (Matrix Z)) unMM
+--     -- 3.
+--   , prop_matmul @(Matrix S)        @(Conj (Matrix S)) unMM
+--   , prop_matmul @(Matrix D)        @(Conj (Matrix D)) unMM
+--   , prop_matmul @(Matrix C)        @(Conj (Matrix C)) unMM
+--   , prop_matmul @(Matrix Z)        @(Conj (Matrix Z)) unMM
+--   , prop_matmul @(Tr (Matrix S))   @(Conj (Matrix S)) unMM
+--   , prop_matmul @(Tr (Matrix D))   @(Conj (Matrix D)) unMM
+--   , prop_matmul @(Tr (Matrix C))   @(Conj (Matrix C)) unMM
+--   , prop_matmul @(Tr (Matrix Z))   @(Conj (Matrix Z)) unMM
+--   , prop_matmul @(Conj (Matrix S)) @(Conj (Matrix S)) unMM
+--   , prop_matmul @(Conj (Matrix D)) @(Conj (Matrix D)) unMM
+--   , prop_matmul @(Conj (Matrix C)) @(Conj (Matrix C)) unMM
+--   , prop_matmul @(Conj (Matrix Z)) @(Conj (Matrix Z)) unMM
   ]
 
 -- Test for generalized matrix-vector multiplication.
@@ -119,10 +119,10 @@ newtype MM a b = MM { unMM :: (a,b) }
 instance (Show a, Show b) => Show (MM a b) where
   show (MM (a,b)) = show a ++ "\n" ++ show b
 
-instance (NDim a ~ 2, NDim b ~ 2, ArbitraryShape a, ArbitraryShape b) => Arbitrary (MM a b) where
-  arbitrary = do
-    (n,k,m) <- genSize
-    MM <$> ((,) <$> arbitraryShape (n,k) <*> arbitraryShape (k,m))
+-- instance (NDim a ~ 2, NDim b ~ 2, ArbitraryShape a, ArbitraryShape b) => Arbitrary (MM a b) where
+--   arbitrary = do
+--     (n,k,m) <- genSize
+--     MM <$> ((,) <$> arbitraryShape (n,k) <*> arbitraryShape (k,m))
 
 -- | Generate matrix and vector with correct size for multiplication
 newtype MV a b = MV { unMV :: (a,b) }
@@ -130,7 +130,7 @@ newtype MV a b = MV { unMV :: (a,b) }
 instance (Show a, Show b) => Show (MV a b) where
   show (MV (a,b)) = show a ++ "\n" ++ show b
 
-instance (NDim a ~ 2, NDim b ~ 1, ArbitraryShape a, ArbitraryShape b) => Arbitrary (MV a b) where
+instance (NDim m ~ 2, NDim v ~ 1, ArbitraryShape m a, ArbitraryShape v a) => Arbitrary (MV (m a) (v a)) where
   arbitrary = do
     (n,k) <- genSize
     MV <$> ((,) <$> arbitraryShape (n,k) <*> arbitraryShape k)

--- a/vecvec-lapack/tests/TST/MatMul.hs
+++ b/vecvec-lapack/tests/TST/MatMul.hs
@@ -30,86 +30,87 @@ import Vecvec.LAPACK.Internal.Matrix.Dense (Matrix)
 import Vecvec.LAPACK.FFI                   (S,D,C,Z)
 
 import TST.Tools.MatModel
+import TST.Tools.Model                     (TestData1(..))
 import TST.Tools.Util
 
 tests :: TestTree
 tests = testGroup "MatMul" 
   [ -- Matrix-vector
-    prop_matmul @(Matrix S)      @(VV.Vec S) unMV
-  , prop_matmul @(Matrix D)      @(VV.Vec D) unMV
-  , prop_matmul @(Matrix C)      @(VV.Vec C) unMV
-  , prop_matmul @(Matrix Z)      @(VV.Vec Z) unMV
-  -- , prop_matmul @(Tr Matrix S)   @(VV.Vec S) unMV
-  -- , prop_matmul @(Tr Matrix D)   @(VV.Vec D) unMV
-  -- , prop_matmul @(Tr Matrix C)   @(VV.Vec C) unMV
-  -- , prop_matmul @(Tr Matrix Z)   @(VV.Vec Z) unMV
-  -- , prop_matmul @(Conj Matrix S) @(VV.Vec S) unMV
-  -- , prop_matmul @(Conj Matrix D) @(VV.Vec D) unMV
-  -- , prop_matmul @(Conj Matrix C) @(VV.Vec C) unMV
-  -- , prop_matmul @(Conj Matrix Z) @(VV.Vec Z) unMV
---     -- Matrix-matrix
---     -- 1.
---   , prop_matmul @(Matrix S)        @(Matrix S) unMM
---   , prop_matmul @(Matrix D)        @(Matrix D) unMM
---   , prop_matmul @(Matrix C)        @(Matrix C) unMM
---   , prop_matmul @(Matrix Z)        @(Matrix Z) unMM
---   , prop_matmul @(Tr (Matrix S))   @(Matrix S) unMM
---   , prop_matmul @(Tr (Matrix D))   @(Matrix D) unMM
---   , prop_matmul @(Tr (Matrix C))   @(Matrix C) unMM
---   , prop_matmul @(Tr (Matrix Z))   @(Matrix Z) unMM
---   , prop_matmul @(Conj (Matrix S)) @(Matrix S) unMM
---   , prop_matmul @(Conj (Matrix D)) @(Matrix D) unMM
---   , prop_matmul @(Conj (Matrix C)) @(Matrix C) unMM
---   , prop_matmul @(Conj (Matrix Z)) @(Matrix Z) unMM
---     -- 2.
---   , prop_matmul @(Matrix S)        @(Tr (Matrix S)) unMM
---   , prop_matmul @(Matrix D)        @(Tr (Matrix D)) unMM
---   , prop_matmul @(Matrix C)        @(Tr (Matrix C)) unMM
---   , prop_matmul @(Matrix Z)        @(Tr (Matrix Z)) unMM
---   , prop_matmul @(Tr (Matrix S))   @(Tr (Matrix S)) unMM
---   , prop_matmul @(Tr (Matrix D))   @(Tr (Matrix D)) unMM
---   , prop_matmul @(Tr (Matrix C))   @(Tr (Matrix C)) unMM
---   , prop_matmul @(Tr (Matrix Z))   @(Tr (Matrix Z)) unMM
---   , prop_matmul @(Conj (Matrix S)) @(Tr (Matrix S)) unMM
---   , prop_matmul @(Conj (Matrix D)) @(Tr (Matrix D)) unMM
---   , prop_matmul @(Conj (Matrix C)) @(Tr (Matrix C)) unMM
---   , prop_matmul @(Conj (Matrix Z)) @(Tr (Matrix Z)) unMM
---     -- 3.
---   , prop_matmul @(Matrix S)        @(Conj (Matrix S)) unMM
---   , prop_matmul @(Matrix D)        @(Conj (Matrix D)) unMM
---   , prop_matmul @(Matrix C)        @(Conj (Matrix C)) unMM
---   , prop_matmul @(Matrix Z)        @(Conj (Matrix Z)) unMM
---   , prop_matmul @(Tr (Matrix S))   @(Conj (Matrix S)) unMM
---   , prop_matmul @(Tr (Matrix D))   @(Conj (Matrix D)) unMM
---   , prop_matmul @(Tr (Matrix C))   @(Conj (Matrix C)) unMM
---   , prop_matmul @(Tr (Matrix Z))   @(Conj (Matrix Z)) unMM
---   , prop_matmul @(Conj (Matrix S)) @(Conj (Matrix S)) unMM
---   , prop_matmul @(Conj (Matrix D)) @(Conj (Matrix D)) unMM
---   , prop_matmul @(Conj (Matrix C)) @(Conj (Matrix C)) unMM
---   , prop_matmul @(Conj (Matrix Z)) @(Conj (Matrix Z)) unMM
+    prop_matmul @Matrix        @VV.Vec @S unMV
+  , prop_matmul @Matrix        @VV.Vec @D unMV
+  , prop_matmul @Matrix        @VV.Vec @C unMV
+  , prop_matmul @Matrix        @VV.Vec @Z unMV
+  , prop_matmul @(Tr Matrix)   @VV.Vec @S unMV
+  , prop_matmul @(Tr Matrix)   @VV.Vec @D unMV
+  , prop_matmul @(Tr Matrix)   @VV.Vec @C unMV
+  , prop_matmul @(Tr Matrix)   @VV.Vec @Z unMV
+  , prop_matmul @(Conj Matrix) @VV.Vec @S unMV
+  , prop_matmul @(Conj Matrix) @VV.Vec @D unMV
+  , prop_matmul @(Conj Matrix) @VV.Vec @C unMV
+  , prop_matmul @(Conj Matrix) @VV.Vec @Z unMV
+    -- Matrix-matrix
+    -- 1.
+  , prop_matmul @Matrix        @Matrix @S unMM
+  , prop_matmul @Matrix        @Matrix @D unMM
+  , prop_matmul @Matrix        @Matrix @C unMM
+  , prop_matmul @Matrix        @Matrix @Z unMM
+  , prop_matmul @(Tr Matrix)   @Matrix @S unMM
+  , prop_matmul @(Tr Matrix)   @Matrix @D unMM
+  , prop_matmul @(Tr Matrix)   @Matrix @C unMM
+  , prop_matmul @(Tr Matrix)   @Matrix @Z unMM
+  , prop_matmul @(Conj Matrix) @Matrix @S unMM
+  , prop_matmul @(Conj Matrix) @Matrix @D unMM
+  , prop_matmul @(Conj Matrix) @Matrix @C unMM
+  , prop_matmul @(Conj Matrix) @Matrix @Z unMM
+    -- 2.
+  , prop_matmul @Matrix        @(Tr Matrix) @S unMM
+  , prop_matmul @Matrix        @(Tr Matrix) @D unMM
+  , prop_matmul @Matrix        @(Tr Matrix) @C unMM
+  , prop_matmul @Matrix        @(Tr Matrix) @Z unMM
+  , prop_matmul @(Tr Matrix)   @(Tr Matrix) @S unMM
+  , prop_matmul @(Tr Matrix)   @(Tr Matrix) @D unMM
+  , prop_matmul @(Tr Matrix)   @(Tr Matrix) @C unMM
+  , prop_matmul @(Tr Matrix)   @(Tr Matrix) @Z unMM
+  , prop_matmul @(Conj Matrix) @(Tr Matrix) @S unMM
+  , prop_matmul @(Conj Matrix) @(Tr Matrix) @D unMM
+  , prop_matmul @(Conj Matrix) @(Tr Matrix) @C unMM
+  , prop_matmul @(Conj Matrix) @(Tr Matrix) @Z unMM
+    -- 3.
+  , prop_matmul @Matrix        @(Conj Matrix) @S unMM
+  , prop_matmul @Matrix        @(Conj Matrix) @D unMM
+  , prop_matmul @Matrix        @(Conj Matrix) @C unMM
+  , prop_matmul @Matrix        @(Conj Matrix) @Z unMM
+  , prop_matmul @(Tr Matrix)   @(Conj Matrix) @S unMM
+  , prop_matmul @(Tr Matrix)   @(Conj Matrix) @D unMM
+  , prop_matmul @(Tr Matrix)   @(Conj Matrix) @C unMM
+  , prop_matmul @(Tr Matrix)   @(Conj Matrix) @Z unMM
+  , prop_matmul @(Conj Matrix) @(Conj Matrix) @S unMM
+  , prop_matmul @(Conj Matrix) @(Conj Matrix) @D unMM
+  , prop_matmul @(Conj Matrix) @(Conj Matrix) @C unMM
+  , prop_matmul @(Conj Matrix) @(Conj Matrix) @Z unMM
   ]
 
 -- Test for generalized matrix-vector multiplication.
 prop_matmul
-  :: forall v1 v2 vR a.
-     ( TestMatrix v1, TestMatrix v2, TestMatrix vR
-     , Eq vR, Show vR, Show (ModelM vR), Typeable v1, Typeable v2
-     , MatMul (ModelM v1) (ModelM v2) (ModelM vR)
-     , MatMul v1 v2 vR
-     , Arbitrary a, Show a
+  :: forall v1 v2 a vR p.
+     ( TestMatrix1 v1 a, TestMatrix1 v2 a, TestMatrix1 vR a
+     , MatMul (Model1M v1 a) (Model1M v2 a) (Model1M vR a)
+     , MatMul (v1 a)         (v2 a)         (vR a)
+     , Typeable v1, Typeable v2, Typeable a
+     , Eq (vR a), Show (vR a), Show (Model1M vR a), Show p, Arbitrary p
      )
-  => (a -> (ModelM v1, ModelM v2))
+  => (p -> (Model1M v1 a, Model1M v2 a))
   -> TestTree
 prop_matmul to_pair
-  = testProperty (qualTypeName @v1 ++ " x " ++ qualTypeName @v2)
+  = testProperty (qualTypeName @v1 ++ " x " ++ qualTypeName @v2 ++ " / " ++ qualTypeName @a)
   $ \(to_pair -> (m1, m2)) ->
-      let v1 = fromModel m1 :: v1
-          v2 = fromModel m2 :: v2
+      let v1 = liftUnmodel TagMat id m1 :: v1 a
+          v2 = liftUnmodel TagMat id m2 :: v2 a
           m  = m1 @@ m2
           v  = v1 @@ v2
       in id $ counterexample ("MODEL = " ++ show m)
             $ counterexample ("IMPL  = " ++ show v)
-            $ v == fromModel m
+            $ v == liftUnmodel TagMat id m
 
 
 
@@ -119,10 +120,10 @@ newtype MM a b = MM { unMM :: (a,b) }
 instance (Show a, Show b) => Show (MM a b) where
   show (MM (a,b)) = show a ++ "\n" ++ show b
 
--- instance (NDim a ~ 2, NDim b ~ 2, ArbitraryShape a, ArbitraryShape b) => Arbitrary (MM a b) where
---   arbitrary = do
---     (n,k,m) <- genSize
---     MM <$> ((,) <$> arbitraryShape (n,k) <*> arbitraryShape (k,m))
+instance (NDim m1 ~ 2, NDim m2 ~ 2, ArbitraryShape m1 a, ArbitraryShape m2 a) => Arbitrary (MM (m1 a) (m2 a)) where
+  arbitrary = do
+    (n,k,m) <- genSize
+    MM <$> ((,) <$> arbitraryShape (n,k) <*> arbitraryShape (k,m))
 
 -- | Generate matrix and vector with correct size for multiplication
 newtype MV a b = MV { unMV :: (a,b) }

--- a/vecvec-lapack/tests/TST/Tools/Model.hs
+++ b/vecvec-lapack/tests/TST/Tools/Model.hs
@@ -13,6 +13,8 @@
 module TST.Tools.Model
   ( -- * Model-related classes
     TestData(..)
+  , Model1
+  , TestData1(..)
   , TestEquiv(..)
   , EqTest
   , LiftTestEq(..)
@@ -32,6 +34,7 @@ import Data.Bifunctor
 import Data.Coerce
 import Data.Complex
 import Data.Function
+import Data.Kind
 import Data.Functor.Identity
 import Data.Functor.Classes
 import Data.Vector           qualified as DV
@@ -56,6 +59,14 @@ class TestData t a where
   type Model t a
   model   :: t -> a -> Model t a
   unmodel :: t -> Model t a -> a
+
+type family Model1 t (v :: Type -> Type) :: Type -> Type
+
+-- | Analog of 'TestData' for @* -> *@ kinded types.
+class TestData1 t v a where
+  liftModel   :: t -> (a -> b) -> v a -> Model1 t v b
+  liftUnmodel :: t -> (b -> a) -> Model1 t v b -> v a
+
 
 -- | Equivalence relation between data types. It's same as 'Eq' except
 --   for treatment of NaNs.
@@ -264,16 +275,3 @@ instance (DVP.Prim a,     TestEquiv a) => TestEquiv (DVP.Vector a) where equiv =
 instance (DVS.Storable a, TestEquiv a) => TestEquiv (DVS.Vector a) where equiv = DVS.eqBy equiv
 instance (DVU.Unbox a,    TestEquiv a) => TestEquiv (DVU.Vector a) where equiv = DVU.eqBy equiv
 instance (DVS.Storable a, TestEquiv a) => TestEquiv (VV.Vec a)     where equiv = DVG.eqBy equiv
-
-
-----------------------------------------
--- Vecvec
-
--- instance (TestData t (v a), v' a' ~ Model t (v a)) => TestData t (Tr v a) where
---   type Model t (Tr v a) = Tr v' a'
-
--- deriving via ModelFunctor Tr a instance TestData t a => TestData t (Tr a)
--- deriving via ModelFunctor Tr a instance TestEquiv  a => TestEquiv  (Tr a)
-
--- deriving via ModelFunctor Conj a instance TestData t a => TestData t (Conj a)
--- deriving via ModelFunctor Conj a instance TestEquiv  a => TestEquiv  (Conj a)

--- a/vecvec-lapack/tests/TST/Tools/Model.hs
+++ b/vecvec-lapack/tests/TST/Tools/Model.hs
@@ -269,8 +269,11 @@ instance (DVS.Storable a, TestEquiv a) => TestEquiv (VV.Vec a)     where equiv =
 ----------------------------------------
 -- Vecvec
 
-deriving via ModelFunctor Tr a instance TestData t a => TestData t (Tr a)
-deriving via ModelFunctor Tr a instance TestEquiv  a => TestEquiv  (Tr a)
+-- instance (TestData t (v a), v' a' ~ Model t (v a)) => TestData t (Tr v a) where
+--   type Model t (Tr v a) = Tr v' a'
 
-deriving via ModelFunctor Conj a instance TestData t a => TestData t (Conj a)
-deriving via ModelFunctor Conj a instance TestEquiv  a => TestEquiv  (Conj a)
+-- deriving via ModelFunctor Tr a instance TestData t a => TestData t (Tr a)
+-- deriving via ModelFunctor Tr a instance TestEquiv  a => TestEquiv  (Tr a)
+
+-- deriving via ModelFunctor Conj a instance TestData t a => TestData t (Conj a)
+-- deriving via ModelFunctor Conj a instance TestEquiv  a => TestEquiv  (Conj a)

--- a/vecvec-lapack/tests/TST/VectorSpace.hs
+++ b/vecvec-lapack/tests/TST/VectorSpace.hs
@@ -43,22 +43,25 @@ import TST.Tools.Util
 
 tests :: TestTree
 tests = testGroup "VectorSpace instances"
-  [ props_inner_space @(VV.Vec S)
-  , props_inner_space @(VV.Vec D)
-  , props_inner_space @(VV.Vec C)
-  , props_inner_space @(VV.Vec Z)
+  [ props_inner_space @VV.Vec @S
+  , props_inner_space @VV.Vec @D
+  , props_inner_space @VV.Vec @C
+  , props_inner_space @VV.Vec @Z
     -- Matrix
-  , props_vector_space @(Matrix S)
-  , props_vector_space @(Matrix D)
-  , props_vector_space @(Matrix C)
-  , props_vector_space @(Matrix Z)
+  , props_vector_space @Matrix @S
+  , props_vector_space @Matrix @D
+  , props_vector_space @Matrix @C
+  , props_vector_space @Matrix @Z
     -- Vector instances
-  , props_inner_space @(V.Vector  Double)
-  , props_inner_space @(VU.Vector Double)
-  , props_inner_space @(VS.Vector Double)
+  , props_inner_space @V.Vector  @D
+  , props_inner_space @VU.Vector @D
+  , props_inner_space @VS.Vector @D
+  , props_inner_space @V.Vector  @Z
+  , props_inner_space @VU.Vector @Z
+  , props_inner_space @VS.Vector @Z
   ]
 
-  
+
 
 ----------------------------------------------------------------
 --
@@ -66,137 +69,162 @@ tests = testGroup "VectorSpace instances"
 
 -- Tests for vector space implementation
 props_inner_space
-  :: forall v a. ( TestMatrix v, TestMatrix a, TestMatrix (R a), TestEquiv v, TestEquiv a, TestEquiv (R a)
-                 , ArbitraryShape (ModelM v)
-                 , InnerSpace v, InnerSpace (ModelM v)
-                 , Typeable v, Show v, Show (ModelM v)
-                 , a ~ Scalar v
-                 , a ~ Scalar (ModelM v)
-                 , a ~ ModelM a
+  :: forall v a. ( TestMatrix (v a), TestMatrix (R a), TestMatrix a, TestEquiv a, TestEquiv (R a)
+                 , InnerSpace (v a)
+                 , InnerSpace (ModelM (v a))
+                 , a ~ Scalar (v a)
+                 , a ~ Scalar (ModelM (v a))
+                 , a   ~ ModelM a
                  , R a ~ ModelM (R a)
-                 , Show (R a), SmallScalar a, Show a
+                 , TestEquiv (v a)
+                 , Arbitrary (Pair (ModelM (v a)))
+                 , Arbitrary       (ModelM (v a))
+                 , SmallScalar     a
+                 , Show (ModelM (v a)), Show (v a), Show a, Show (R a)
+                 , Typeable v, Typeable a
                  )
   => TestTree
-props_inner_space = testGroup (qualTypeName @v)
-  [ prop_addition_correct    @v
-  , prop_subtraction_correct @v
-  , prop_negation_correct    @v
-  , prop_lmul_scalar         @v
-  , prop_rmul_scalar         @v
-  , prop_scalar_product      @v
-  , prop_magnitude           @v
+props_inner_space = testGroup (qualTypeName @v ++ " (" ++ qualTypeName @a ++ ")")
+  [ prop_addition_correct    @v @a
+  , prop_subtraction_correct @v @a
+  , prop_negation_correct    @v @a
+  , prop_lmul_scalar         @v @a
+  , prop_rmul_scalar         @v @a
+  , prop_scalar_product      @v @a
+  , prop_magnitude           @v @a
   ]
 
 -- Tests for vector space implementation
 props_vector_space
-  :: forall v a. ( TestMatrix v, TestEquiv v, VectorSpace v, VectorSpace (ModelM v), ArbitraryShape (ModelM v)
-                 , Typeable v, Show v, Show (ModelM v)
-                 , Scalar v ~ a, Scalar (ModelM v) ~ a
-                 , SmallScalar a, Show a
+  :: forall v a. ( TestMatrix (v a)
+                 , VectorSpace (v a)
+                 , VectorSpace (ModelM (v a))
+                 , a ~ Scalar (v a)
+                 , a ~ Scalar (ModelM (v a))
+                 , TestEquiv (v a)
+                 , Arbitrary (Pair (ModelM (v a)))
+                 , Arbitrary       (ModelM (v a))
+                 , SmallScalar     a
+                 , Show            (ModelM (v a)), Show (v a), Show a
+                 , Typeable v, Typeable a
                  )
   => TestTree
-props_vector_space = testGroup (qualTypeName @v)
-  [ prop_addition_correct    @v
-  , prop_subtraction_correct @v
-  , prop_negation_correct    @v
-  , prop_lmul_scalar         @v
-  , prop_rmul_scalar         @v
+props_vector_space = testGroup (qualTypeName @v ++ " (" ++ qualTypeName @a ++ ")")
+  [ prop_addition_correct    @v @a
+  , prop_subtraction_correct @v @a
+  , prop_negation_correct    @v @a
+  , prop_lmul_scalar         @v @a
+  , prop_rmul_scalar         @v @a
   ]
-
-
 
 -- Model evaluate addition in the same way as implementation
 prop_addition_correct
-  :: forall v. ( TestMatrix v, AdditiveSemigroup v, AdditiveSemigroup (ModelM v), ArbitraryShape (ModelM v)
-               , TestEquiv v, Show (ModelM v)
-               )
+  :: forall v a. ( TestMatrix (v a)
+                 , AdditiveSemigroup (v a), AdditiveSemigroup (ModelM (v a))
+                 , TestEquiv (v a)
+                 , Arbitrary (Pair (ModelM (v a)))
+                 , Show (ModelM (v a))
+                 )
   => TestTree
 prop_addition_correct
   = testProperty "Addition"
-  $ (mdl @(Pair v) $ eq @v)
+  $ (mdl $ eq @(v a))
     (\(Pair v1 v2) -> v1 .+. v2)
     (\(Pair v1 v2) -> v1 .+. v2)
 
 -- Model evaluate subtraction in the same way as implementation
 prop_subtraction_correct
-  :: forall v. ( TestMatrix v, TestEquiv v, AdditiveQuasigroup v, AdditiveQuasigroup (ModelM v), ArbitraryShape (ModelM v)
-               , Show (ModelM v)
-               )
+  :: forall v a. ( TestMatrix (v a)
+                 , AdditiveQuasigroup (v a), AdditiveQuasigroup (ModelM (v a))
+                 , TestEquiv (v a)
+                 , Arbitrary (Pair (ModelM (v a)))
+                 , Show (ModelM (v a))
+                 )
   => TestTree
 prop_subtraction_correct
   = testProperty "Subtraction"
-  $ (mdl $ eq @v)
+  $ (mdl $ eq @(v a))
     (\(Pair v1 v2) -> v1 .-. v2)
     (\(Pair v1 v2) -> v1 .-. v2)
 
 -- Model evaluate negation in the same way as implementation
 prop_negation_correct
-  :: forall v. ( TestMatrix v, AdditiveQuasigroup v, AdditiveQuasigroup (ModelM v), ArbitraryShape (ModelM v)
-               , TestEquiv v, Show (ModelM v)
-               )
+  :: forall v a. ( TestMatrix (v a)
+                 , AdditiveQuasigroup (v a), AdditiveQuasigroup (ModelM (v a))
+                 , TestEquiv (v a)
+                 , Arbitrary (ModelM (v a))
+                 , Show      (ModelM (v a))
+                 )
   => TestTree
 prop_negation_correct
   = testProperty "Negation"
-  $ (mdl $ eq @v)
+  $ (mdl $ eq @(v a))
     negateV
     negateV
 
 -- Model evaluates multiplication by scalar on the left
 prop_lmul_scalar
-  :: forall v a. ( TestMatrix v, VectorSpace v, VectorSpace (ModelM v), ArbitraryShape (ModelM v)
-                 , TestEquiv v, Show v, Show (ModelM v)
-                 , Scalar v ~ a, Scalar (ModelM v) ~ a
-                 , SmallScalar a, Show a
+  :: forall v a. ( TestMatrix (v a), TestEquiv (v a)
+                 , VectorSpace (v a), VectorSpace (ModelM (v a))
+                 , Scalar (v a) ~ a,  Scalar (ModelM (v a)) ~ a
+                 , Show a, Show (v a), Show (ModelM (v a))
+                 , Arbitrary (ModelM (v a))
+                 , SmallScalar a
                  )
   => TestTree
 prop_lmul_scalar
   = testProperty "Left scalar multiplication"
-  $ (val @(X a)  $  mdl @v  $  eqV)
+  $ (val @(X a)  $  mdl @(v a) $ eqV @(v a))
     (\(X a) v -> a *. v)
     (\(X a) v -> a *. v)
 
 -- Model evaluates multiplication by scalar on the right
 prop_rmul_scalar
-  :: forall v a. ( TestMatrix v, VectorSpace v, VectorSpace (ModelM v), ArbitraryShape (ModelM v)
-                 , TestEquiv v, Show v, Show (ModelM v)
-                 , Scalar v ~ a, Scalar (ModelM v) ~ a
-                 , SmallScalar a, Show a
+  :: forall v a. ( TestMatrix (v a), TestEquiv (v a)
+                 , VectorSpace (v a), VectorSpace (ModelM (v a))
+                 , Scalar (v a) ~ a,  Scalar (ModelM (v a)) ~ a
+                 , Show a, Show (v a), Show (ModelM (v a))
+                 , Arbitrary (ModelM (v a))
+                 , SmallScalar a
                  )
   => TestTree
 prop_rmul_scalar
   = testProperty "Right scalar multiplication"
-  $ (val @(X a)  $  mdl @v  $  eqV)
+  $ (val @(X a)  $  mdl @(v a)  $  eqV @(v a))
     (\(X a) v -> v .* a)
     (\(X a) v -> v .* a)
 
 -- Model evaluates scalar product in the same way
 prop_scalar_product
-  :: forall v a. ( TestMatrix v, TestMatrix a, ArbitraryShape (ModelM v)
-                 , InnerSpace v, InnerSpace (ModelM v)
-                 , Show (ModelM v)
-                 , a ~ Scalar v
-                 , a ~ Scalar (ModelM v)
-                 , a ~ ModelM a 
-                 , TestEquiv a)
+  :: forall v a. ( TestMatrix (v a), TestMatrix a, TestEquiv a
+                 , InnerSpace (v a), InnerSpace (ModelM (v a))
+                 , Show (ModelM (v a))
+                 , a ~ Scalar (v a)
+                 , a ~ Scalar (ModelM (v a))
+                 , a ~ ModelM a
+                 , Arbitrary (Pair (ModelM (v a)))
+                 )
   => TestTree
 prop_scalar_product
   = testProperty "Scalar product"
-  $ (mdl @(Pair v)  $  eq)
+  $ (mdl @(Pair (v a))  $  eq)
     (\(Pair v1 v2) -> v1 <.> v2)
     (\(Pair v1 v2) -> v1 <.> v2)
- 
+
 -- Model evaluates magnitude in the same way
 prop_magnitude
-  :: forall v a. ( TestMatrix v, TestMatrix (R a), TestEquiv (R a), ArbitraryShape (ModelM v)
-                 , InnerSpace v, InnerSpace (ModelM v)
-                 , Show (ModelM v)
-                 , a ~ Scalar v
-                 , a ~ Scalar (ModelM v)
+  :: forall v a. ( TestMatrix (v a), TestMatrix (R a), TestEquiv (R a)
+                 , InnerSpace (v a), InnerSpace (ModelM (v a))
+                 , Show (ModelM (v a))
+                 , a   ~ Scalar (v a)
+                 , a   ~ Scalar (ModelM (v a))
                  , R a ~ ModelM (R a)
-                 , Show (R a))
+                 , Show (R a)
+                 , Arbitrary (ModelM (v a))
+                 )
   => TestTree
 prop_magnitude
   = testProperty "Magnitude"
-  $ (mdl @v  $  eqV)
+  $ (mdl @(v a)  $  eqV @(R a))
      magnitudeSq
      magnitudeSq

--- a/vecvec-lapack/tests/TST/VectorSpace.hs
+++ b/vecvec-lapack/tests/TST/VectorSpace.hs
@@ -69,19 +69,17 @@ tests = testGroup "VectorSpace instances"
 
 -- Tests for vector space implementation
 props_inner_space
-  :: forall v a. ( TestMatrix (v a), TestMatrix (R a), TestMatrix a, TestEquiv a, TestEquiv (R a)
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (v a), TestEquiv a, TestEquiv (R a)
                  , InnerSpace (v a)
-                 , InnerSpace (ModelM (v a))
+                 , InnerSpace (Model1M v a)
                  , a ~ Scalar (v a)
-                 , a ~ Scalar (ModelM (v a))
-                 , a   ~ ModelM a
-                 , R a ~ ModelM (R a)
-                 , TestEquiv (v a)
-                 , Arbitrary (Pair (ModelM (v a)))
-                 , Arbitrary       (ModelM (v a))
-                 , SmallScalar     a
-                 , Show (ModelM (v a)), Show (v a), Show a, Show (R a)
+                 , a ~ Scalar (Model1M v a)
+                 , Show a
                  , Typeable v, Typeable a
+                 , ArbitraryShape (Model1M v) a
+                 , Arbitrary      (Model1M v a)
+                 , SmallScalar    a
+                 , Show (Model1M v a)
                  )
   => TestTree
 props_inner_space = testGroup (qualTypeName @v ++ " (" ++ qualTypeName @a ++ ")")
@@ -96,17 +94,18 @@ props_inner_space = testGroup (qualTypeName @v ++ " (" ++ qualTypeName @a ++ ")"
 
 -- Tests for vector space implementation
 props_vector_space
-  :: forall v a. ( TestMatrix (v a)
+  :: forall v a. ( TestMatrix1 v a
                  , VectorSpace (v a)
-                 , VectorSpace (ModelM (v a))
+                 , VectorSpace (Model1M v a)
                  , a ~ Scalar (v a)
-                 , a ~ Scalar (ModelM (v a))
+                 , a ~ Scalar (Model1M v a)
                  , TestEquiv (v a)
-                 , Arbitrary (Pair (ModelM (v a)))
-                 , Arbitrary       (ModelM (v a))
-                 , SmallScalar     a
-                 , Show            (ModelM (v a)), Show (v a), Show a
+                 , SmallScalar a
+                 , Show a
                  , Typeable v, Typeable a
+                 , ArbitraryShape (Model1M v) a
+                 , Arbitrary      (Model1M v a)
+                 , Show (Model1M v a)
                  )
   => TestTree
 props_vector_space = testGroup (qualTypeName @v ++ " (" ++ qualTypeName @a ++ ")")
@@ -119,112 +118,108 @@ props_vector_space = testGroup (qualTypeName @v ++ " (" ++ qualTypeName @a ++ ")
 
 -- Model evaluate addition in the same way as implementation
 prop_addition_correct
-  :: forall v a. ( TestMatrix (v a)
-                 , AdditiveSemigroup (v a), AdditiveSemigroup (ModelM (v a))
-                 , TestEquiv (v a)
-                 , Arbitrary (Pair (ModelM (v a)))
-                 , Show (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (v a)
+                 , AdditiveSemigroup (v a), AdditiveSemigroup (Model1M v a)
+                 , ArbitraryShape (Model1M v) a
+                 , Show           (Model1M v a)
                  )
   => TestTree
 prop_addition_correct
   = testProperty "Addition"
-  $ (mdl $ eq @(v a))
-    (\(Pair v1 v2) -> v1 .+. v2)
-    (\(Pair v1 v2) -> v1 .+. v2)
+  $ (mdl1 $ eq1 @v @a)
+    (\(Pair1 v1 v2) -> v1 .+. v2)
+    (\(Pair1 v1 v2) -> v1 .+. v2)
 
 -- Model evaluate subtraction in the same way as implementation
 prop_subtraction_correct
-  :: forall v a. ( TestMatrix (v a)
-                 , AdditiveQuasigroup (v a), AdditiveQuasigroup (ModelM (v a))
-                 , TestEquiv (v a)
-                 , Arbitrary (Pair (ModelM (v a)))
-                 , Show (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (v a)
+                 , AdditiveQuasigroup (v a), AdditiveQuasigroup (Model1M v a)
+                 , ArbitraryShape (Model1M v) a
+                 , Show           (Model1M v a)
                  )
   => TestTree
 prop_subtraction_correct
   = testProperty "Subtraction"
-  $ (mdl $ eq @(v a))
-    (\(Pair v1 v2) -> v1 .-. v2)
-    (\(Pair v1 v2) -> v1 .-. v2)
+  $ (mdl1 $ eq1 @v @a)
+    (\(Pair1 v1 v2) -> v1 .-. v2)
+    (\(Pair1 v1 v2) -> v1 .-. v2)
 
 -- Model evaluate negation in the same way as implementation
 prop_negation_correct
-  :: forall v a. ( TestMatrix (v a)
-                 , AdditiveQuasigroup (v a), AdditiveQuasigroup (ModelM (v a))
-                 , TestEquiv (v a)
-                 , Arbitrary (ModelM (v a))
-                 , Show      (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (v a)
+                 , AdditiveQuasigroup (v a), AdditiveQuasigroup (Model1M v a)
+                 , Arbitrary (Model1M v a)
+                 , Show      (Model1M v a)
                  )
   => TestTree
 prop_negation_correct
   = testProperty "Negation"
-  $ (mdl $ eq @(v a))
+  $ (mdl1 $ eq1 @v @a)
     negateV
     negateV
 
 -- Model evaluates multiplication by scalar on the left
 prop_lmul_scalar
-  :: forall v a. ( TestMatrix (v a), TestEquiv (v a)
-                 , VectorSpace (v a), VectorSpace (ModelM (v a))
-                 , Scalar (v a) ~ a,  Scalar (ModelM (v a)) ~ a
-                 , Show a, Show (v a), Show (ModelM (v a))
-                 , Arbitrary (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (v a)
+                 , VectorSpace (v a), VectorSpace (Model1M v a)
+                 , a ~ Scalar (v a)
+                 , a ~ Scalar (Model1M v a)
+                 , Show a, Show (Model1M v a)
+                 , Arbitrary (Model1M v a)
                  , SmallScalar a
                  )
   => TestTree
 prop_lmul_scalar
   = testProperty "Left scalar multiplication"
-  $ (val @(X a)  $  mdl @(v a) $ eqV @(v a))
+  $ (val @(X a)  $  mdl1 $ eq1 @v @a)
     (\(X a) v -> a *. v)
     (\(X a) v -> a *. v)
 
 -- Model evaluates multiplication by scalar on the right
 prop_rmul_scalar
-  :: forall v a. ( TestMatrix (v a), TestEquiv (v a)
-                 , VectorSpace (v a), VectorSpace (ModelM (v a))
-                 , Scalar (v a) ~ a,  Scalar (ModelM (v a)) ~ a
-                 , Show a, Show (v a), Show (ModelM (v a))
-                 , Arbitrary (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (v a)
+                 , VectorSpace (v a), VectorSpace (Model1M v a)
+                 , a ~ Scalar (v a)
+                 , a ~ Scalar (Model1M v a)
+                 , Show a, Show (Model1M v a)
+                 , Arbitrary (Model1M v a)
                  , SmallScalar a
                  )
   => TestTree
 prop_rmul_scalar
   = testProperty "Right scalar multiplication"
-  $ (val @(X a)  $  mdl @(v a)  $  eqV @(v a))
+  $ (val @(X a)  $  mdl1  $  eq1 @v @a)
     (\(X a) v -> v .* a)
     (\(X a) v -> v .* a)
 
 -- Model evaluates scalar product in the same way
 prop_scalar_product
-  :: forall v a. ( TestMatrix (v a), TestMatrix a, TestEquiv a
-                 , InnerSpace (v a), InnerSpace (ModelM (v a))
-                 , Show (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv a
+                 , InnerSpace (v a), InnerSpace (Model1M v a)
                  , a ~ Scalar (v a)
-                 , a ~ Scalar (ModelM (v a))
-                 , a ~ ModelM a
-                 , Arbitrary (Pair (ModelM (v a)))
+                 , a ~ Scalar (Model1M v a)
+                 , ArbitraryShape (Model1M v) a
+                 , Show (Model1M v a)
                  )
   => TestTree
 prop_scalar_product
   = testProperty "Scalar product"
-  $ (mdl @(Pair (v a))  $  eq)
-    (\(Pair v1 v2) -> v1 <.> v2)
-    (\(Pair v1 v2) -> v1 <.> v2)
+  $ (mdl1 @(Pair1 v) @a  $  plainEq)
+    (\(Pair1 v1 v2) -> v1 <.> v2)
+    (\(Pair1 v1 v2) -> v1 <.> v2)
 
 -- Model evaluates magnitude in the same way
 prop_magnitude
-  :: forall v a. ( TestMatrix (v a), TestMatrix (R a), TestEquiv (R a)
-                 , InnerSpace (v a), InnerSpace (ModelM (v a))
-                 , Show (ModelM (v a))
+  :: forall v a. ( TestMatrix1 v a, TestEquiv (R a)
+                 , InnerSpace (v a), InnerSpace (Model1M v a)
+                 , Show (Model1M v a)
                  , a   ~ Scalar (v a)
-                 , a   ~ Scalar (ModelM (v a))
-                 , R a ~ ModelM (R a)
-                 , Show (R a)
-                 , Arbitrary (ModelM (v a))
+                 , a   ~ Scalar (Model1M v a)
+                 , Arbitrary (Model1M v a)
                  )
   => TestTree
 prop_magnitude
   = testProperty "Magnitude"
-  $ (mdl @(v a)  $  eqV @(R a))
+  $ (mdl1 @v @a  $  plainEq @(R a))
      magnitudeSq
      magnitudeSq


### PR DESCRIPTION
This API design is much more in line with standard convention where type of element of a container is encoded as type parameter. And `Elt` type family if very cumbersome to use. 

`Tr` & `Conj` are changed accordingly