### PR TITLE
Introduce BLASInt and LAPACKInt

### DIFF
--- a/vecvec-lapack-ffi/cbits/blastest.c
+++ b/vecvec-lapack-ffi/cbits/blastest.c
@@ -1,0 +1,15 @@
+#include <cblas.h>
+#include <lapacke.h>
+#include <stdint.h>
+#include <assert.h>
+
+
+static_assert(
+    sizeof(blasint) == sizeof(int),
+    "BLAS integer is not of same size as int"
+);
+
+static_assert(
+    sizeof(lapack_int) == sizeof(int),
+    "LAPACK integer is not of same size as int"
+);

--- a/vecvec-lapack-ffi/vecvec-lapack-ffi.cabal
+++ b/vecvec-lapack-ffi/vecvec-lapack-ffi.cabal
@@ -14,6 +14,7 @@ Category:       Data
 Build-Type:     Simple
 extra-source-files:
   ChangeLog.md
+  cbits/blastest.c
 
 source-repository head
   type:     git
@@ -22,6 +23,7 @@ source-repository head
 Library
   Ghc-options:          -Wall
   Default-Language:     Haskell2010
+  c-sources:            cbits/blastest.c
   Build-Depends:        base             >=4.12 && <5
                       , primitive        >=0.7
                       , vecvec-classes

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Dense/Mutable.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Dense/Mutable.hs
@@ -473,9 +473,9 @@ unsafeBlasGemv tr α (asMInput @s -> MView{..}) vecX β (MVec (VecRepr _ incY fp
             unsafeWithForeignPtr fpX    $ \p_x ->
             unsafeWithForeignPtr fpY    $ \p_y ->
               C.gemv C.RowMajor tr
-                (fromIntegral nrows) (fromIntegral ncols) α p_A (fromIntegral leadingDim)
-                p_x (fromIntegral incX)
-                β p_y (fromIntegral incY)
+                (C.toB nrows) (C.toB ncols) α p_A (C.toB leadingDim)
+                p_x (C.toB incX)
+                β p_y (C.toB incY)
 
 -- | General matrix-matrix multiplication
 --
@@ -496,9 +496,9 @@ unsafeBlasGemm α trA (asMInput @s -> matA) trB (asMInput @s -> matB) β (MMatri
     unsafeWithForeignPtr (buffer matB) $ \p_B ->
     unsafeWithForeignPtr (buffer matC) $ \p_C ->
       C.gemm C.RowMajor trA trB
-        (fromIntegral $ if trA == C.NoTrans then nrows matA else ncols matA)
-        (fromIntegral $ if trB == C.NoTrans then ncols matB else nrows matB)
-        (fromIntegral $ if trB == C.NoTrans then nrows matB else ncols matB)
-        α p_A (fromIntegral $ leadingDim matA)
-          p_B (fromIntegral $ leadingDim matB)
-        β p_C (fromIntegral $ leadingDim matC)
+        (C.toB $ if trA == C.NoTrans then nrows matA else ncols matA)
+        (C.toB $ if trB == C.NoTrans then ncols matB else nrows matB)
+        (C.toB $ if trB == C.NoTrans then nrows matB else ncols matB)
+        α p_A (C.toB $ leadingDim matA)
+          p_B (C.toB $ leadingDim matB)
+        β p_C (C.toB $ leadingDim matC)

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Symmetric/Mutable.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Matrix/Symmetric/Mutable.hs
@@ -348,9 +348,9 @@ unsafeBlasSymv α (asSymInput @s -> MSymView{..}) vecX β (MVec (VecRepr _ incY 
             unsafeWithForeignPtr fpX    $ \p_x ->
             unsafeWithForeignPtr fpY    $ \p_y ->
               C.symv C.RowMajor C.UP
-                (fromIntegral size) α p_A (fromIntegral leadingDim)
-                p_x (fromIntegral incX)
-                β p_y (fromIntegral incY)
+                (C.toB size) α p_A (C.toB leadingDim)
+                p_x (C.toB incX)
+                β p_y (C.toB incY)
 
 -- | Multiplication of general matrix @B@ by symmetric matrix @A@ on the left
 --
@@ -373,10 +373,10 @@ unsafeBlasSymmL α (asSymInput @s -> matA) (asMInput @s -> matB) β (asMInput @s
     unsafeWithForeignPtr matB.buffer $ \p_B ->
     unsafeWithForeignPtr matC.buffer $ \p_C -> do
       C.symm C.RowMajor C.LeftSide C.UP
-        (fromIntegral matC.nrows) (fromIntegral matC.ncols)
-        α p_A (fromIntegral matA.leadingDim)
-          p_B (fromIntegral matB.leadingDim)
-        β p_C (fromIntegral matC.leadingDim)
+        (C.toB matC.nrows) (C.toB matC.ncols)
+        α p_A (C.toB matA.leadingDim)
+          p_B (C.toB matB.leadingDim)
+        β p_C (C.toB matC.leadingDim)
 
 -- | Multiplication of general matrix @B@ by symmetric matrix @A@ on the right
 --
@@ -399,7 +399,7 @@ unsafeBlasSymmR α (asMInput @s -> matB) (asSymInput @s -> matA) β (asMInput @s
     unsafeWithForeignPtr matB.buffer $ \p_B ->
     unsafeWithForeignPtr matC.buffer $ \p_C -> do
       C.symm C.RowMajor C.RightSide C.UP
-        (fromIntegral matC.nrows) (fromIntegral matC.ncols)
-        α p_A (fromIntegral matA.leadingDim)
-          p_B (fromIntegral matB.leadingDim)
-        β p_C (fromIntegral matC.leadingDim)
+        (C.toB matC.nrows) (C.toB matC.ncols)
+        α p_A (C.toB matA.leadingDim)
+          p_B (C.toB matB.leadingDim)
+        β p_C (C.toB matC.leadingDim)

--- a/vecvec-lapack/Vecvec/LAPACK/Internal/Vector/Mutable.hs
+++ b/vecvec-lapack/Vecvec/LAPACK/Internal/Vector/Mutable.hs
@@ -293,7 +293,7 @@ clone vecIn
        unsafeWithForeignPtr fp $ \p -> do
          vecOut@(MVec (VecRepr _ inc' fp')) <- MVG.unsafeNew len
          unsafeWithForeignPtr fp' $ \p' -> do
-           C.copy (fromIntegral len) p (fromIntegral inc) p' (fromIntegral inc')
+           C.copy (C.toB len) p (C.toB inc) p' (C.toB inc')
          return $ coerce vecOut
 
 
@@ -323,8 +323,8 @@ unsafeBlasAxpy a vecX (MVec (VecRepr _ incY fpY)) = unsafePrimToPrim $ do
   VecRepr lenX incX fpX <- unsafePrimToPrim $ asInput @s vecX
   id $ unsafeWithForeignPtr fpX $ \pX ->
        unsafeWithForeignPtr fpY $ \pY ->
-       C.axpy (fromIntegral lenX) a pX (fromIntegral incX)
-                                    pY (fromIntegral incY)
+       C.axpy (C.toB lenX) a pX (C.toB incX)
+                             pY (C.toB incY)
 
 -- | Multiply vector by scalar in place
 --
@@ -337,7 +337,7 @@ blasScal
 blasScal a (MVec (VecRepr lenX incX fpX))
   = unsafePrimToPrim
   $ unsafeWithForeignPtr fpX $ \pX ->
-    C.scal (fromIntegral lenX) a pX (fromIntegral incX)
+    C.scal (C.toB lenX) a pX (C.toB incX)
 
 
 
@@ -367,7 +367,7 @@ unsafeBlasDotu vecX vecY = unsafePrimToPrim $ do
   VecRepr _    incY fpY <- unsafePrimToPrim $ asInput @s vecY
   id $ unsafeWithForeignPtr fpX $ \pX ->
        unsafeWithForeignPtr fpY $ \pY ->
-       C.dot (fromIntegral lenX) pX (fromIntegral incX) pY (fromIntegral incY)
+       C.dot (C.toB lenX) pX (C.toB incX) pY (C.toB incY)
 
 -- | Compute scalar product of two vectors. First vector is complex
 --   conjugated. See 'blasDotc' for variant without conjugation.
@@ -395,7 +395,7 @@ unsafeBlasDotc vecX vecY = unsafePrimToPrim $ do
   VecRepr _    incY fpY <- unsafePrimToPrim $ asInput @s vecY
   id $ unsafeWithForeignPtr fpX $ \pX ->
        unsafeWithForeignPtr fpY $ \pY ->
-       C.dotc (fromIntegral lenX) pX (fromIntegral incX) pY (fromIntegral incY)
+       C.dotc (C.toB lenX) pX (C.toB incX) pY (C.toB incY)
 
 -- | Compute euclidean norm or vector:
 --
@@ -408,4 +408,4 @@ blasNrm2 vec
   = unsafePrimToPrim
   $ do VecRepr lenX incX fpX <- unsafePrimToPrim $ asInput @s vec
        unsafeWithForeignPtr fpX $ \pX ->
-         C.nrm2 (fromIntegral lenX) pX (fromIntegral incX)
+         C.nrm2 (C.toB lenX) pX (C.toB incX)


### PR DESCRIPTION
BLAS could use both 32 and 64 bit integers so we want to make sure that we pass correctly sized integers. LAPACK however seems to always use 32bit. This makes it possible to switch to 64bit or use both variants as compile time configuration

Additionally we check during compilation that sizes are correct.